### PR TITLE
Phase 7c — OpenTelemetry traces and a Jaeger checkout view

### DIFF
--- a/.superpowers/sdd/2026-07-29-phase-7c-tracing/acceptance.md
+++ b/.superpowers/sdd/2026-07-29-phase-7c-tracing/acceptance.md
@@ -1,0 +1,302 @@
+# Phase 7c — End-to-end tracing acceptance evidence
+
+Date: 2026-07-29. Branch `feat/phase-7c-tracing`. Stack brought up via
+`docker-compose.example.yml` + a local host-port-remap override (postgres 5433, mailpit
+1026/8026, `build.network: host`) so it coexists with an unrelated `eda-platform` stack
+already holding 5432/9090/4318/1025/8025 on this machine. `kafka-ui`, `prometheus`, and
+`grafana` were left out of the `up` invocation — `kafka-ui` collides with the eda-platform
+stack on host port 8080 (not covered by the override) and neither is needed to verify
+tracing, so the services were started explicitly: `postgres kafka rabbitmq mailpit redis
+jaeger hello inventory order payment catalog notification identity gateway`.
+
+## 1. Services reporting to Jaeger
+
+```
+$ curl -s http://localhost:16686/api/services
+{"data":["notification","identity","inventory","catalog","gateway","jaeger-all-in-one","payment","order"],"total":8}
+```
+
+All 7 application services plus Jaeger's own self-instrumentation. **`hello` is absent** —
+expected and pre-existing: its container CrashLoops because its runtime `CMD` shells out to
+corepack, which tries to fetch pnpm from `registry.npmjs.org` at container startup and cannot
+reach it in this environment. `services/hello/Dockerfile` is untouched by 7b or 7c. Confirmed
+from the container's own logs:
+
+```
+{"level":"info","message":"tracing_started","pid":1,"service":"hello","timestamp":"2026-07-29T12:23:04.723Z"}
+! Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-10.28.0.tgz
+Error: getaddrinfo EAI_AGAIN registry.npmjs.org
+```
+
+Tracing itself starts fine inside the container (`tracing_started` logs) — it never gets the
+chance to emit an HTTP span because the process dies before `app.listen`. This is the same
+limitation noted for `hello`'s Prometheus target; its spans cannot be verified in-container.
+
+## 2. Real checkout, saga settled
+
+Driven entirely through the gateway on `:8000` (register → promote to ADMIN via a direct DB
+update, since there is no seeded admin account or self-service promotion → login again for a
+fresh JWT carrying the `ADMIN` role claim → create a product → seed inventory stock directly
+against `:3001` since the gateway has no `/inventory` mount → add to cart → place order),
+following the exact double-submit CSRF + `name`-field-on-register + `/cart` (not
+`/orders/cart`) details called out in the brief.
+
+- User: `trace-e2e-1785328177@example.test`
+- Product: `7c0a4fe6-0c15-4d2d-9c34-9bbc48c3a26d` ("Trace Widget 7c", ELECTRONICS, price 900 —
+  chosen so `simulateCharge`'s `amount % 100` deterministically resolves `SUCCEEDED`, not the
+  async `PROCESSING` leg)
+- Order: `cfde8b55-3deb-4870-b347-4affcb922a05`, placed `PENDING` → polled `CONFIRMED` after 2
+  polls (~1s)
+
+Confirmed **from each service's own database**, not from HTTP responses:
+
+```
+order:      SELECT id, status, "totalPrice" FROM "Order" WHERE id='cfde...';
+            -> CONFIRMED, 900
+
+payment:    SELECT id, "orderId", status, amount FROM "Payment" WHERE "orderId"='cfde...';
+            -> SUCCEEDED, 900
+
+inventory:  SELECT id, "orderId", "productId", status FROM "Reservation" WHERE "orderId"='cfde...';
+            -> CONSUMED
+
+notification: SELECT id, "orderId", type, status, "to" FROM "Notification" WHERE "orderId"='cfde...';
+            -> order.placed   SENT
+            -> order.confirmed SENT
+```
+
+Full saga settled: order CONFIRMED, payment SUCCEEDED, reservation CONSUMED, both
+notifications SENT.
+
+## 3. The trace — queried via Jaeger's HTTP API, not eyeballed
+
+```
+$ curl -s "http://localhost:16686/api/traces?service=gateway&limit=20"
+```
+
+returns 20 traces for `gateway`; the checkout trace is unmistakable as the only one with
+hundreds of spans (`340`) against everything else's dozens:
+
+```
+traceID                            spans
+...
+bcbc3988614ac2fc0e08b7a7e002f31e   340   <- the checkout
+...
+```
+
+```
+$ curl -s "http://localhost:16686/api/traces/bcbc3988614ac2fc0e08b7a7e002f31e"
+```
+
+`processes` in that trace: `{p1: order, p2: notification, p3: payment, p4: inventory, p5:
+gateway}` — **all five required hops present**, including payment.
+
+### Span timeline (business + producer/consumer spans only; `prisma:*` internal spans elided)
+
+Timestamps are ms from the trace's first span (`gateway POST /orders` server span).
+
+| t (ms) | dur (ms) | service | kind | span |
+|---|---|---|---|---|
+| 0.0 | 13.40 | gateway | server | `POST /orders` |
+| 2.0 | 10.76 | gateway | client | `POST` (proxy call to order) |
+| 3.0 | 9.47 | order | server | `POST /orders` (price, create order, clear cart, enqueue outbox — one tx) |
+| 135.0 | 1.65 | order | producer | `order.events publish` |
+| 138.0 | 6.81 | inventory | consumer | `order.events process` (reserve) |
+| 138.0 | 5.99 | notification | consumer | `order.events process` (order.placed email) |
+| 424.0 | 1.54 | notification | producer | `notifications send` |
+| 426.0 | 59.68 | notification | consumer | `notifications process` (SMTP to mailpit) |
+| 544.0 | 2.29 | inventory | producer | `inventory.events publish` |
+| 549.0 | 8.84 | order | consumer | `inventory.events process` (→ AWAITING_PAYMENT, enqueue payment.charge) |
+| 635.0 | 1.33 | order | producer | **`payment.charge send`** |
+| 637.0 | 8.71 | payment | consumer | **`payment.charge process`** |
+| 877.0 | 1.99 | payment | producer | `payment.events publish` |
+| 879.0 | 12.03 | order | consumer | `payment.events process` (→ CONFIRMED, enqueue order.confirmed) |
+| 1136.0 | 1.08 | order | producer | `order.events publish` |
+| 1138.0 | 3.11 | inventory | consumer | `order.events process` (mark reservation CONSUMED) |
+| 1138.0 | 4.85 | notification | consumer | `order.events process` (order.confirmed email) |
+| 1427.0 | 1.13 | notification | producer | `notifications send` |
+| 1428.0 | 45.91 | notification | consumer | `notifications process` (SMTP to mailpit) |
+
+Total spans in the trace: 340 (the rest are `@prisma/instrumentation`'s per-query engine
+sub-spans, several per business DB call).
+
+### 3a. Payment hop — present, and confirmably over RabbitMQ
+
+The `payment.charge send` → `payment.charge process` pair is a direct `CHILD_OF` reference
+(order's producer span `a32b75a050692700` is the parent of payment's consumer span
+`ac375a924c6ac538`), and the two sides' `otel.scope.name` tags prove which transport carried
+it:
+
+```
+order   "payment.charge send"    otel.scope.name = @ecom/shared/outbox      (producer wrapper; same for every relay lane)
+payment "payment.charge process" otel.scope.name = @ecom/shared/rabbitmq    span.kind=consumer
+                                  messaging.destination.name = payment.charge
+                                  messaging.message.id = fbebe7b9-9a44-4284-87f2-0c9a2051cc80
+```
+
+Contrast with a same-trace Kafka hop (`order.events process` on inventory):
+
+```
+inventory "order.events process" otel.scope.name = @ecom/shared/kafka       span.kind=consumer
+                                  messaging.destination.name = order.events
+```
+
+`@ecom/shared/kafka` vs. `@ecom/shared/rabbitmq` on the two consumer spans is the concrete,
+quotable proof that the payment leg specifically travelled over RabbitMQ (Task 7's seam) and
+not Kafka — the one failure mode this step exists to catch.
+
+### 3b. The relay polling gap — visible at every hop
+
+Gap = (business span end) → (next producer span start). All six relay-mediated hops in the
+trace show a positive, non-trivial gap, consistent with the 500ms outbox-relay poll interval
+(the size of each gap is just the phase offset between "row committed" and "next poll tick"):
+
+| business span ends | next publish/send starts | gap |
+|---|---|---|
+| order `POST /orders` @ 12.47ms | order `order.events publish` @ 135.0ms | **122.5ms** |
+| inventory `order.events process` @ 144.8ms | inventory `inventory.events publish` @ 544.0ms | **399.2ms** |
+| order `inventory.events process` @ 557.8ms | order `payment.charge send` @ 635.0ms | **77.2ms** |
+| payment `payment.charge process` @ 645.7ms | payment `payment.events publish` @ 877.0ms | **231.3ms** |
+| order `payment.events process` @ 891.0ms | order `order.events publish` @ 1136.0ms | **245.0ms** |
+| notification `order.events process` @ 1142.9ms | notification `notifications send` @ 1427.0ms | **284.1ms** |
+
+Every gap sits inside `(0, 500ms]`, exactly as expected for a 500ms poll: this is the
+design's central promise (Task 6/7's relay never republishes into the caller's own span —
+it parents to the *stored* context and injects its *own* — so the gap between the DB write and
+the wire send is now a real, visible, measurable thing instead of hidden inside one span).
+
+## 4. `traceId` round-trip from an order-service log line
+
+```
+$ docker logs ecom-platform-order-1 | grep 'cfde8b55-3deb-4870-b347-4affcb922a05' | grep order_placed
+{"level":"info","message":"order_placed","orderId":"cfde8b55-3deb-4870-b347-4affcb922a05","service":"order","timestamp":"2026-07-29T12:29:38.013Z","traceId":"bcbc3988614ac2fc0e08b7a7e002f31e"}
+
+$ curl -s "http://localhost:16686/api/traces/bcbc3988614ac2fc0e08b7a7e002f31e" | jq '.data | length'
+1
+```
+
+The `traceId` printed in the order service's own structured log line finds **exactly** the
+trace inspected above — one trace, 340 spans, same five services. Step 4's discrimination
+check passes: this is not a coincidental match, it is the actual trace the checkout produced.
+
+## 5. Idle span rate (no traffic, 60s window)
+
+Measured with the stack fully up, no application traffic in flight, over a clean 60-second
+window (`1785327967` → `1785328027` epoch seconds), by summing `spans` across every trace
+`GET /api/traces?service=<svc>&start=<us>&end=<us>&limit=3000` returned per service:
+
+| service | traces | spans |
+|---|---|---|
+| gateway | 6 | 72 |
+| order | 126 | 939 |
+| inventory | 582 | **8581** |
+| payment | 126 | 939 |
+| catalog | 126 | 939 |
+| notification | 126 | 939 |
+| identity | 127 | 958 |
+| **total** | **1219** | **13,367** |
+
+**Measured idle floor: 13,367 spans/min (≈ 223 spans/sec).**
+
+`packages/shared/src/outbox.ts`'s relay does **not** create a span on an empty poll tick —
+`publishWithSpan` only runs inside the per-row send lane, confirmed by reading the code. The
+floor instead comes from: (a) `@prisma/instrumentation`'s query span tree on the relay's own
+`fetchUnsent` call, which every service's 500ms outbox poll issues regardless of whether it
+finds rows (this produces several spans per tick, not one — order/payment/catalog/notification
+all land within a spans-per-60s band of 939, ≈120–130 poll ticks × ~7 spans each); (b) the
+10s-interval Docker healthcheck (`GET /readyz`) hitting Express + Prisma instrumentation on
+every service, plus a Redis ping on inventory's; (c) identity's slightly higher count is its
+own poll cadence plus healthcheck shape.
+
+**`inventory` is a 9x outlier and it is explained, not mysterious:** its 5-second reservation
+sweeper (`services/inventory/src/sweeper.ts`) is permanently retrying **37 stale `ACTIVE`
+reservations** left over from previous days' manual/test runs, whose `productId`s no longer
+have a row in the `Inventory` table (deleted or never-recreated since those rows were
+written). Every 5s tick, `sweepOnce()` re-queries the same 37 rows, groups them into ~34
+distinct orders, and each one's `prisma.$transaction` throws
+(`prisma.inventory.update()` → "No record was found for an update") — confirmed directly from
+the container's own logs (`sweep_order_failed`, repeated every 5s, same 34 `orderId`s each
+time). The rows are never marked `RELEASED` because the failure happens before that write, so
+this is a steady-state loop, not a one-time backlog drain — it will keep firing every 5s
+indefinitely until someone manually clears those 37 rows or reseeds their products. Each failed
+attempt still burns a full Prisma span tree before throwing, which is where inventory's extra
+~7,600 spans/min come from.
+
+This is pre-existing dev-database drift (accumulated across `2026-07-21` .. `2026-07-29`
+manual runs against this long-lived shared Postgres), not a defect in Phase 7c's tracing or
+relay code — but it does mean the raw 13,367/min number is **not representative of a healthy
+deployment's floor**. Subtracting inventory's anomaly (i.e., assuming it behaved like its
+five outbox-relay peers, ~939 spans/60s) gives a **corrected idle floor of ≈5,725 spans/min
+(≈95 spans/sec)** across all 7 services — this is the number 7d should use for sizing a
+sampling ratio; the raw 13,367/min is what you'd actually observe on *this* machine right now
+without first cleaning the stale reservations.
+
+The DLQ poller (`packages/shared/src/metrics.ts`'s `startDlqPoller`, 15s interval, used by
+payment and notification) queries RabbitMQ's queue-depth over its management API, which is not
+in `ENABLED_INSTRUMENTATIONS` (only http/express/redis/prisma are) — it contributes ~0 spans to
+the floor.
+
+## 6. What did not work / concerns
+
+- **`hello` cannot be verified** — pre-existing corepack/registry issue, documented above and
+  in the task-9 brief up front. Not a tracing defect.
+- **`kafka-ui` could not be started** with the literal `docker compose ... --profile app up -d
+  --build` command from the brief — it collides with the unrelated `eda-platform` stack on
+  host port 8080, which the prepared override did not remap (only postgres/mailpit were
+  remapped). This aborted the compose run before `gateway` started. Worked around by listing
+  the exact services needed (`postgres kafka rabbitmq mailpit redis jaeger hello inventory
+  order payment catalog notification identity gateway`), skipping `kafka-ui`,
+  `prometheus`, and `grafana`, none of which this task needs. Not a 7c code defect — an
+  environment-override gap, now known for next time.
+- **No seeded admin account, and no self-service promotion path.** `services/identity/prisma/seed.ts`
+  seeds `ADMIN`'s grants but never a `User` row. Becoming `ADMIN` requires a direct
+  `UPDATE "User" SET "roleId" = ...` against identity's own Postgres DB followed by a fresh
+  login (the role is a JWT claim minted at login, not looked up per request) — this matches
+  the documented pattern in `docs/runbooks/phase-6-auth-demo.md`, so it is expected behaviour,
+  not a gap this phase introduced.
+- **Inventory has no gateway mount.** `POST /inventory/stock` must be called directly against
+  `:3001`; the gateway's `Upstreams` type has no `inventory` entry at all. Expected/documented
+  by the brief itself, noted here for completeness.
+- **One flaky test, confirmed environmental, not a regression:**
+  `services/order/src/__tests__/order-stream.e2e.test.ts` ("streams PENDING/AWAITING_PAYMENT
+  -> CONFIRMED for a real placed order") fails when run as part of the full `services/order`
+  suite (reproduced 3×: default parallel run, `--no-file-parallelism`, and with the live
+  `ecom-platform-order-1` container stopped — all three still failed), but **passes cleanly in
+  isolation** (550ms, single run). Since it fails identically with the live container both up
+  and down, the cause is contention among the order service's *own* e2e/int test files sharing
+  Kafka consumer-group state within one vitest process, not interference from the acceptance
+  checkout or the live compose stack. No 7c commit touches this test file or the SSE registry
+  (`git log` on the file shows no phase-7c changes). Flagging as a known pre-existing flake
+  for follow-up — not treated as a regression in the pass/fail counts below, but not hidden
+  either.
+
+## 7. Full regression
+
+`pnpm -r typecheck`: clean, all 9 workspace packages/services.
+`pnpm format:check`: clean.
+
+Per-service (against `postgresql://ecom:ecom@localhost:5433/<db>` — the brief's own snippet
+says `:5432`, but the ENVIRONMENT section for this task explicitly overrides that to `5433` for
+this machine, and per the plan's own adjudication rule, an explicit environment fact wins over
+the brief's literal text):
+
+| service | files | tests |
+|---|---|---|
+| hello | 2 passed | 2 passed |
+| inventory | 10 passed | 30 passed |
+| order | 17 passed, **1 failed*** | 67 passed, **1 failed*** |
+| payment | 11 passed | 46 passed |
+| catalog | 10 passed | 34 passed |
+| notification | 8 passed | 20 passed |
+| identity | 6 passed | 28 passed |
+| gateway | 4 passed | 41 passed |
+| packages | 32 passed | 115 passed |
+| **total** | **100 files (99 passed, 1 failed)** | **383 passed, 1 failed (384 total)** |
+
+\* `order-stream.e2e.test.ts`, see §6 — passes in isolation, fails only alongside its sibling
+files within the same `services/order` vitest invocation, reproduced with the live `order`
+container both running and stopped. Root-caused to shared Kafka consumer-group state across
+the order suite's own test files, not to phase 7c's changes.
+
+384 total tests recorded here (356 pre-existing + the tracing tests added across Tasks 1–8),
+consistent with the plan's expectation.

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -103,6 +103,18 @@ services:
       - ./infra/grafana/dashboards:/var/lib/grafana/dashboards:ro
     depends_on: [prometheus]
 
+  jaeger:
+    image: jaegertracing/all-in-one:1.62.0
+    restart: unless-stopped
+    ports: ["16686:16686"]   # UI only — OTLP stays in-network, like the gateway's metrics port
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:14269/"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
   # Application services live behind the `app` profile so `docker compose up`
   # brings up only infra by default:  docker compose --profile app up -d hello
   hello:
@@ -116,6 +128,9 @@ services:
       KAFKA_BROKERS: kafka:19092
       REDIS_URL: redis://redis:6379
       PORT: 3000
+      OTEL_SERVICE_NAME: hello
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4318
+      NODE_OPTIONS: --import tsx --import file:///repo/packages/shared/src/tracing.ts
     ports: ["3000:3000"]
     depends_on:
       postgres: { condition: service_healthy }
@@ -140,6 +155,9 @@ services:
       RESERVATION_TTL_MS: 900000
       SWEEP_INTERVAL_MS: 5000
       PORT: 3001
+      OTEL_SERVICE_NAME: inventory
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4318
+      NODE_OPTIONS: --import tsx --import file:///repo/packages/shared/src/tracing.ts
     ports: ["3001:3001"]
     depends_on:
       postgres: { condition: service_healthy }
@@ -163,6 +181,9 @@ services:
       RABBITMQ_URL: amqp://${RABBITMQ_USER:-ecom}:${RABBITMQ_PASSWORD:-ecom}@rabbitmq:5672
       PORT: 3002
       LOG_LEVEL: info
+      OTEL_SERVICE_NAME: order
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4318
+      NODE_OPTIONS: --import tsx --import file:///repo/packages/shared/src/tracing.ts
     ports: ["3002:3002"]
     depends_on:
       postgres: { condition: service_healthy }
@@ -186,6 +207,9 @@ services:
       KAFKA_BROKERS: kafka:19092
       PAYMENT_WEBHOOK_SECRET: ${PAYMENT_WEBHOOK_SECRET}
       PORT: 3003
+      OTEL_SERVICE_NAME: payment
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4318
+      NODE_OPTIONS: --import tsx --import file:///repo/packages/shared/src/tracing.ts
     ports: ["3003:3003"]
     depends_on:
       postgres: { condition: service_healthy }
@@ -207,6 +231,9 @@ services:
       DATABASE_URL: postgresql://${POSTGRES_USER:-ecom}:${POSTGRES_PASSWORD:-ecom}@postgres:5432/catalog
       KAFKA_BROKERS: kafka:19092
       PORT: 3004
+      OTEL_SERVICE_NAME: catalog
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4318
+      NODE_OPTIONS: --import tsx --import file:///repo/packages/shared/src/tracing.ts
     ports: ["3004:3004"]
     depends_on:
       postgres: { condition: service_healthy }
@@ -231,6 +258,9 @@ services:
       SMTP_PORT: 1025
       NOTIFY_EMAIL_DOMAIN: example.test
       PORT: 3005
+      OTEL_SERVICE_NAME: notification
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4318
+      NODE_OPTIONS: --import tsx --import file:///repo/packages/shared/src/tracing.ts
     ports: ["3005:3005"]
     depends_on:
       postgres: { condition: service_healthy }
@@ -258,6 +288,9 @@ services:
       ACCESS_TTL: 15m
       REFRESH_TTL_DAYS: 7
       PORT: 3006
+      OTEL_SERVICE_NAME: identity
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4318
+      NODE_OPTIONS: --import tsx --import file:///repo/packages/shared/src/tracing.ts
     ports: ["3006:3006"]
     depends_on:
       postgres: { condition: service_healthy }
@@ -289,6 +322,9 @@ services:
       # Deliberately not published: Prometheus reaches gateway:9464 over the compose
       # network, and /metrics stays unreachable from the host.
       METRICS_PORT: 9464
+      OTEL_SERVICE_NAME: gateway
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4318
+      NODE_OPTIONS: --import tsx --import file:///repo/packages/shared/src/tracing.ts
     ports: ["8000:8000"]
     depends_on:
       identity: { condition: service_healthy }

--- a/docker-compose.prod.example.yml
+++ b/docker-compose.prod.example.yml
@@ -26,6 +26,8 @@ services:
     ports: !reset []
   grafana:
     ports: !reset []
+  jaeger:
+    ports: !reset []
 
   hello:
     ports: !reset []

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -31,6 +31,7 @@ before migrating or running the service:
 | Mailpit    | http://localhost:8025   | SMTP on 1025; see below       |
 | Prometheus | http://localhost:9090   | `/targets`; needs `--profile app` |
 | Grafana    | http://localhost:3007   | admin / `GRAFANA_PASSWORD` from `.env` |
+| Jaeger     | http://localhost:16686  | traces; needs `--profile app` |
 
 Grafana is on **3007**, not its usual 3000 — the services already occupy 3000-3006.
 Both are provisioned from disk (`infra/grafana/provisioning`), so the Prometheus
@@ -53,6 +54,12 @@ docker compose --profile app up -d
 Prometheus and Grafana are deliberately **not** in the `app` profile: monitoring the
 stack is useful while you are bringing services up one at a time, so they come up with
 infra.
+
+Traces are exported to `jaeger:4318` over the compose network; the OTLP ports
+(4317/4318) are deliberately unpublished, so nothing on the host can post spans
+directly — only the Jaeger UI on 16686 is reachable. A `traceId` from any service's
+log line is the search term to paste into the Jaeger UI to pull up that request's
+trace.
 
 **Your local `docker-compose.yml` can drift behind `docker-compose.example.yml`.**
 It is your own gitignored copy (`cp docker-compose.example.yml docker-compose.yml`

--- a/docs/superpowers/plans/2026-07-29-phase-7c-tracing.md
+++ b/docs/superpowers/plans/2026-07-29-phase-7c-tracing.md
@@ -1,0 +1,1176 @@
+# Phase 7c — OpenTelemetry traces & Jaeger — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** One checkout produces one Jaeger trace spanning gateway → order → inventory → payment → notification, with the outbox relay's polling delay visible as a gap between hops.
+
+**Architecture:** Auto-instrumentation (HTTP, Express, Prisma, redis) is loaded by a `NODE_OPTIONS=--import` preload and covers the synchronous seams. The asynchronous seams are owned manually: `traceparent` rides inside the `EventEnvelope` (not broker headers), is persisted on each `Outbox` row, and is re-injected by the relay so consumers can parent to it. `traceId` stops being a minted uuid and becomes the W3C trace ID, so a log line pastes straight into Jaeger.
+
+**Tech Stack:** `@opentelemetry/sdk-node`, `@opentelemetry/api`, `@opentelemetry/auto-instrumentations-node`, `@opentelemetry/exporter-trace-otlp-http`, `@prisma/instrumentation@^6.19`, Jaeger all-in-one. TypeScript, tsx, pnpm workspaces, vitest.
+
+**Spec:** `docs/superpowers/specs/2026-07-29-phase-7c-tracing-design.md`
+
+## Global Constraints
+
+Every task's requirements implicitly include this section.
+
+1. **Nothing may throw into a production path.** Span creation, context injection and context extraction are each wrapped and log-and-continue on failure. A malformed `traceparent` starts a fresh trace; it never rejects a message. This is the constraint 7a and 7b were both adjudicated against — it is binding, not advisory.
+2. **Record after the transaction resolves**, never inside a tx callback and never in a pure domain module.
+3. **`traceparent` is OPTIONAL on the envelope.** A required field dead-letters every event in flight during deploy. Precedent: `ChargePayment.userId` needed `.partial({ userId: true })` for exactly this reason.
+4. **kafkajs and amqplib auto-instrumentations are OFF.** They propagate via broker headers while this system propagates via the envelope; enabling both yields traces that are correct on sync hops and quietly wrong on async ones.
+5. **Exact package names** — these were verified against npm and two obvious guesses are wrong:
+   - `@opentelemetry/instrumentation-redis` — NOT `instrumentation-redis-4` (deprecated), NOT `ioredis` (wrong client).
+   - `@prisma/instrumentation@^6.19` — NOT latest (7.x), because every service pins `@prisma/client: ^6.1.0`.
+6. **Prisma migrations via CLI only.** `pnpm --filter @ecom/<svc> exec prisma migrate dev --name <change>`. Hand-writing or editing files under `prisma/migrations/` is blocked by `.claude/hooks/prisma-migration-guard.sh` and breaks Prisma's checksums.
+7. **The `quality` CI lane runs with no database and no env files.** Any test that imports a service's `config` at module scope must be named `*.int.test.ts`. This is what failed CI at the end of 7b.
+8. **Never commit** `docker-compose.yml`, `.env`, or any secret. `docker-compose.example.yml` and `.env.example` are the committed templates.
+9. **No sensitive data in span attributes.** Span attributes are logs by another name — IDs and codes only, never payloads, emails, tokens or names. Enforced by `.claude/rules/sensitive-logging.md`.
+10. **Commit specific files, never `git add -A`.** Every task ends with `pnpm -r typecheck && pnpm format:check` clean.
+11. **No business-logic change.** All 356 tests from the 7b merge must pass **unmodified**.
+
+**Local infra:** integration tests need `docker compose --profile app up -d`. An unrelated `eda-platform` stack on this machine holds 5432, 9090, 4318 and 1025/8025; 7b used a scratchpad `-f` override to remap rather than stopping it. Run `bash infra/scripts/reset-dev-topics.sh` before trusting any e2e failure — a long-lived broker accumulates replay history until the 25s poll budgets break.
+
+---
+
+### Task 1: `traceparent` on the event contract
+
+**Files:**
+- Modify: `packages/contracts/src/envelope.ts`
+- Test: `packages/contracts/src/__tests__/envelope.unit.test.ts` (create if absent)
+
+**Interfaces:**
+- Produces: `EventEnvelope.traceparent?: string`; `makeEnvelope(input: { …, traceparent?: string })` passes it through.
+
+Everything downstream depends on this, so it lands first and alone.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { EventEnvelopeSchema, makeEnvelope } from "../envelope";
+
+const W3C = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+describe("envelope traceparent", () => {
+  it("carries traceparent through makeEnvelope", () => {
+    const env = makeEnvelope({
+      type: "order.placed",
+      version: 1,
+      traceId: "t",
+      producer: "test",
+      payload: {},
+      traceparent: W3C,
+    });
+    expect(env.traceparent).toBe(W3C);
+  });
+
+  // Deploy safety: an event minted before this deploy has no traceparent at all.
+  // If this ever becomes required, every in-flight event dead-letters.
+  it("parses an envelope with NO traceparent", () => {
+    const parsed = EventEnvelopeSchema.parse({
+      eventId: "3f1a7c62-9b0e-4f5d-8a21-2c7e6d4b1f90",
+      type: "order.placed",
+      version: 1,
+      occurredAt: new Date().toISOString(),
+      traceId: "t",
+      producer: "test",
+      payload: {},
+    });
+    expect(parsed.traceparent).toBeUndefined();
+  });
+
+  it("omits traceparent when the caller supplies none", () => {
+    const env = makeEnvelope({
+      type: "order.placed",
+      version: 1,
+      traceId: "t",
+      producer: "test",
+      payload: {},
+    });
+    expect(env.traceparent).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `pnpm vitest run packages/contracts/src/__tests__/envelope.unit.test.ts`
+Expected: FAIL — `traceparent` is not a known property.
+
+- [ ] **Step 3: Add the field**
+
+In `packages/contracts/src/envelope.ts`, add to `EventEnvelopeSchema` after `producer`:
+
+```ts
+  // Optional by design: an event minted before Phase 7c carries none, and a required
+  // field would retry-then-dead-letter every event in flight during the deploy.
+  traceparent: z.string().optional(),
+```
+
+Add to `makeEnvelope`'s input type: `traceparent?: string;`
+
+And to its returned object, after `producer: input.producer,`:
+
+```ts
+    ...(input.traceparent ? { traceparent: input.traceparent } : {}),
+```
+
+Spread-conditionally rather than assigning `undefined`, so an envelope without a
+traceparent serializes to JSON with no key at all rather than an explicit null.
+
+- [ ] **Step 4: Run and confirm green**
+
+Run: `pnpm vitest run packages/contracts`
+Expected: PASS, all pre-existing contracts tests unmodified.
+
+- [ ] **Step 5: Typecheck, format, commit**
+
+```bash
+pnpm -r typecheck && pnpm format:check
+git add packages/contracts/src/envelope.ts packages/contracts/src/__tests__/envelope.unit.test.ts
+git commit -m "feat(contracts): optional traceparent on the event envelope"
+```
+
+---
+
+### Task 2: The tracing bootstrap
+
+**Files:**
+- Create: `packages/shared/src/tracing.ts`
+- Test: `packages/shared/src/__tests__/tracing.unit.test.ts`
+- Modify: `packages/shared/package.json`
+
+**Interfaces:**
+- Produces: a side-effecting module suitable for `--import`, plus `export function tracingStarted(): boolean` for the test.
+
+**Do NOT export this from `packages/shared/src/index.ts`.** It is a preload, not a library
+import — exporting it would run SDK startup inside every service and every test that imports
+anything from shared.
+
+- [ ] **Step 1: Add dependencies**
+
+```bash
+pnpm --filter @ecom/shared add @opentelemetry/api @opentelemetry/sdk-node \
+  @opentelemetry/auto-instrumentations-node @opentelemetry/exporter-trace-otlp-http \
+  @opentelemetry/instrumentation-redis @opentelemetry/resources \
+  @opentelemetry/semantic-conventions
+pnpm --filter @ecom/shared add @prisma/instrumentation@^6.19
+```
+
+Verify `@prisma/instrumentation` resolved to a 6.x, not 7.x:
+`grep -A1 '"@prisma/instrumentation"' packages/shared/package.json`
+
+- [ ] **Step 2: Write the failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+
+describe("tracing bootstrap", () => {
+  it("is idempotent — a second evaluation does not start a second SDK", async () => {
+    const first = await import("../tracing");
+    expect(first.tracingStarted()).toBe(true);
+    // Re-import with a busted module cache, the way the tsx loader re-evaluates it.
+    const second = await import(`../tracing?reload=${Date.now()}`);
+    expect(second.tracingStarted()).toBe(true);
+    expect(globalThis.__ecomTracingStarted__).toBe(true);
+  });
+
+  it("enables exactly the intended instrumentations and no messaging ones", async () => {
+    const { ENABLED_INSTRUMENTATIONS } = await import("../tracing");
+    expect(ENABLED_INSTRUMENTATIONS).toEqual([
+      "@opentelemetry/instrumentation-http",
+      "@opentelemetry/instrumentation-express",
+      "@opentelemetry/instrumentation-redis",
+      "@prisma/instrumentation",
+    ]);
+    // The load-bearing assertion: these propagate via broker headers while this system
+    // propagates via the envelope. Enabling both yields traces that are correct on sync
+    // hops and quietly wrong on async ones.
+    expect(ENABLED_INSTRUMENTATIONS).not.toContain("@opentelemetry/instrumentation-kafkajs");
+    expect(ENABLED_INSTRUMENTATIONS).not.toContain("@opentelemetry/instrumentation-amqplib");
+  });
+});
+```
+
+- [ ] **Step 3: Run and confirm it fails**
+
+Run: `pnpm vitest run packages/shared/src/__tests__/tracing.unit.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 4: Write the module**
+
+```ts
+// Preload module, loaded via NODE_OPTIONS=--import. NOT exported from index.ts:
+// importing it as a library would start the SDK inside every service and every test.
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { HttpInstrumentation } from "@opentelemetry/instrumentation-http";
+import { ExpressInstrumentation } from "@opentelemetry/instrumentation-express";
+import { RedisInstrumentation } from "@opentelemetry/instrumentation-redis";
+import { PrismaInstrumentation } from "@prisma/instrumentation";
+import { createLogger } from "./logger";
+
+const log = createLogger("tracing");
+
+// The set is explicit, never getNodeAutoInstrumentations(): that bundle includes
+// kafkajs and amqplib, which propagate through broker headers and would compete
+// with this system's envelope-carried context. It also includes fs, which buries
+// a trace in hundreds of spans.
+export const ENABLED_INSTRUMENTATIONS = [
+  "@opentelemetry/instrumentation-http",
+  "@opentelemetry/instrumentation-express",
+  "@opentelemetry/instrumentation-redis",
+  "@prisma/instrumentation",
+] as const;
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __ecomTracingStarted__: boolean | undefined;
+}
+
+// Must live on globalThis, NOT in a module-local variable. The tsx loader evaluates
+// this module more than once, in SEPARATE module registries — a module-local flag is
+// a fresh `false` each time and guards nothing, so the SDK would register duplicate
+// exporters and duplicate instrumentations.
+function start(): void {
+  if (globalThis.__ecomTracingStarted__) return;
+  globalThis.__ecomTracingStarted__ = true;
+
+  try {
+    const sdk = new NodeSDK({
+      traceExporter: new OTLPTraceExporter(),
+      instrumentations: [
+        new HttpInstrumentation(),
+        new ExpressInstrumentation(),
+        new RedisInstrumentation(),
+        new PrismaInstrumentation(),
+      ],
+    });
+    sdk.start();
+    process.once("SIGTERM", () => {
+      void sdk.shutdown().catch(() => {
+        /* shutdown telemetry must never delay or fail process exit */
+      });
+    });
+    log.info("tracing_started", { service: process.env.OTEL_SERVICE_NAME ?? "unknown" });
+  } catch (e) {
+    // Global constraint 1: instrumentation must never take the process down.
+    log.warn("tracing_start_failed", { message: (e as Error).message });
+  }
+}
+
+export function tracingStarted(): boolean {
+  return globalThis.__ecomTracingStarted__ === true;
+}
+
+start();
+```
+
+Service name, endpoint and sampler all come from the standard env vars
+(`OTEL_SERVICE_NAME`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_TRACES_SAMPLER`), which the
+SDK reads itself — no bespoke config schema.
+
+- [ ] **Step 5: Run and confirm green**
+
+Run: `pnpm vitest run packages/shared/src/__tests__/tracing.unit.test.ts`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 6: Verify the preload actually preloads**
+
+This is the mechanism the whole slice rests on, and three things about it were wrong on
+first guess. Confirm it end to end before moving on:
+
+```bash
+cat > /tmp/7c-probe-main.ts <<'EOF'
+console.log("MAIN SECOND");
+EOF
+NODE_OPTIONS="--import tsx --import file://$PWD/packages/shared/src/tracing.ts" \
+  OTEL_SERVICE_NAME=probe npx tsx /tmp/7c-probe-main.ts
+rm -f /tmp/7c-probe-main.ts
+```
+
+Expected: the `tracing_started` log line appears **before** `MAIN SECOND`, and appears
+**once** even though the module is evaluated more than once. If it appears twice, the
+`globalThis` guard is wrong — fix it before continuing.
+
+- [ ] **Step 7: Typecheck, format, commit**
+
+```bash
+pnpm -r typecheck && pnpm format:check
+git add packages/shared/src/tracing.ts packages/shared/src/__tests__/tracing.unit.test.ts \
+        packages/shared/package.json pnpm-lock.yaml
+git commit -m "feat(shared): idempotent OTel bootstrap with an explicit instrumentation set"
+```
+
+---
+
+### Task 3: The HTTP seam — `traceId` becomes the W3C trace ID
+
+**Files:**
+- Modify: `packages/shared/src/trace.ts`
+- Test: `packages/shared/src/__tests__/trace.test.ts` (exists — extend, do not rewrite)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `currentTraceparent(): string | undefined` — used by Tasks 5, 6 and 7.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/shared/src/__tests__/trace.test.ts`:
+
+```ts
+import { context, trace, SpanContext, TraceFlags } from "@opentelemetry/api";
+import { currentTraceparent } from "../trace";
+
+const TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736";
+const SPAN_ID = "00f067aa0ba902b7";
+
+function withSpan<T>(fn: () => T): T {
+  const sc: SpanContext = {
+    traceId: TRACE_ID,
+    spanId: SPAN_ID,
+    traceFlags: TraceFlags.SAMPLED,
+    isRemote: false,
+  };
+  const ctx = trace.setSpanContext(context.active(), sc);
+  return context.with(ctx, fn);
+}
+
+describe("traceId derives from the active span", () => {
+  it("uses the active span's trace id, not a fresh uuid", () => {
+    const req = { header: () => undefined, method: "GET", path: "/x" } as never;
+    const res = { setHeader: () => {} } as never;
+    withSpan(() => traceMiddleware()(req, res, () => {}));
+    expect((req as { traceId: string }).traceId).toBe(TRACE_ID);
+  });
+
+  it("falls back to a uuid when there is no active span (every test run)", () => {
+    const req = { header: () => undefined, method: "GET", path: "/x" } as never;
+    const res = { setHeader: () => {} } as never;
+    traceMiddleware()(req, res, () => {});
+    expect((req as { traceId: string }).traceId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it("currentTraceparent serializes the active span context", () => {
+    expect(withSpan(() => currentTraceparent())).toBe(
+      `00-${TRACE_ID}-${SPAN_ID}-01`
+    );
+  });
+
+  it("currentTraceparent is undefined with no active span", () => {
+    expect(currentTraceparent()).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run and confirm it fails**
+
+Run: `pnpm vitest run packages/shared/src/__tests__/trace.test.ts`
+Expected: FAIL — `currentTraceparent` is not exported.
+
+- [ ] **Step 3: Rewrite the middleware**
+
+In `packages/shared/src/trace.ts`, add the import and replace the traceId derivation:
+
+```ts
+import { trace, context } from "@opentelemetry/api";
+```
+
+```ts
+// The active span's trace id IS the traceId now, so a log line pastes straight into
+// Jaeger. With no active span — every test run, and any service started without the
+// NODE_OPTIONS preload — fall back to the old uuid so nothing that works today stops.
+function activeTraceId(): string | undefined {
+  const sc = trace.getSpanContext(context.active());
+  return sc && sc.traceId !== "00000000000000000000000000000000" ? sc.traceId : undefined;
+}
+
+export function currentTraceparent(): string | undefined {
+  const sc = trace.getSpanContext(context.active());
+  if (!sc || sc.traceId === "00000000000000000000000000000000") return undefined;
+  return `00-${sc.traceId}-${sc.spanId}-${sc.traceFlags.toString(16).padStart(2, "0")}`;
+}
+```
+
+Then in `traceMiddleware`, replace the existing assignment:
+
+```ts
+    const incoming = req.header(TRACE_HEADER);
+    // Precedence: the active span (established by the http instrumentation, which has
+    // already extracted any inbound W3C `traceparent`) > the legacy x-trace-id header >
+    // a fresh uuid. x-trace-id stays supported so external callers keep working.
+    const traceId = activeTraceId() ?? (incoming && incoming.length > 0 ? incoming : uuidv4());
+```
+
+- [ ] **Step 4: Run and confirm green**
+
+Run: `pnpm vitest run packages/shared/src/__tests__/trace.test.ts`
+Expected: PASS — the pre-existing trace tests unmodified plus the 4 new ones.
+
+- [ ] **Step 5: Typecheck, format, commit**
+
+```bash
+pnpm -r typecheck && pnpm format:check
+git add packages/shared/src/trace.ts packages/shared/src/__tests__/trace.test.ts
+git commit -m "feat(shared): traceId derives from the active span, x-trace-id kept as fallback"
+```
+
+---
+
+### Task 4: Persist `traceparent` on the outbox row
+
+**Files:**
+- Modify: `packages/shared/src/outbox.ts`
+- Modify: `services/{hello,inventory,order,payment,catalog,notification,identity}/prisma/schema.prisma`
+- Test: `packages/shared/src/__tests__/outbox.unit.test.ts` (exists — extend)
+
+**Interfaces:**
+- Consumes: `currentTraceparent()` from Task 3; `EventEnvelope.traceparent` from Task 1.
+- Produces: `OutboxRow.traceparent?: string | null`, carried into the relayed envelope.
+
+Seven services own `model Outbox`; gateway has no database. Their `outbox-adapter.ts`
+files all do `rows as unknown as OutboxRow[]`, so **no adapter needs editing** — the
+column and the type are enough.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/shared/src/__tests__/outbox.unit.test.ts`:
+
+```ts
+it("carries the row's traceparent into the relayed envelope", async () => {
+  const TP = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+  const published: EventEnvelope[] = [];
+  const port: OutboxPort = {
+    async fetchUnsent() {
+      return [
+        {
+          id: "11111111-1111-4111-8111-111111111111",
+          aggregateType: "order",
+          aggregateId: "o1",
+          type: "order.placed",
+          version: 1,
+          traceId: "t",
+          traceparent: TP,
+          producer: "order",
+          payload: {},
+          occurredAt: new Date(),
+          sentAt: null,
+        },
+      ];
+    },
+    async markSent() {},
+  };
+  await drainOutbox(port, { async publish(_t, e) { published.push(e); } }, () => "order.events");
+  expect(published[0].traceparent).toBe(TP);
+});
+
+it("relays a row with no traceparent (pre-7c rows) without throwing", async () => {
+  const published: EventEnvelope[] = [];
+  const port: OutboxPort = {
+    async fetchUnsent() {
+      return [
+        {
+          id: "22222222-2222-4222-8222-222222222222",
+          aggregateType: "order",
+          aggregateId: "o2",
+          type: "order.placed",
+          version: 1,
+          traceId: "t",
+          producer: "order",
+          payload: {},
+          occurredAt: new Date(),
+          sentAt: null,
+        },
+      ];
+    },
+    async markSent() {},
+  };
+  await drainOutbox(port, { async publish(_t, e) { published.push(e); } }, () => "order.events");
+  expect(published[0].traceparent).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run and confirm it fails**
+
+Run: `pnpm vitest run packages/shared/src/__tests__/outbox.unit.test.ts`
+Expected: FAIL — `traceparent` is not a property of `OutboxRow`.
+
+- [ ] **Step 3: Extend the type and the builder**
+
+In `packages/shared/src/outbox.ts`, add to `OutboxRow` after `traceId: string;`:
+
+```ts
+  // Nullable: rows written before Phase 7c have none, and Prisma returns null not undefined.
+  traceparent?: string | null;
+```
+
+And in `toEnvelope`, after `traceId: row.traceId,`:
+
+```ts
+    ...(row.traceparent ? { traceparent: row.traceparent } : {}),
+```
+
+- [ ] **Step 4: Run and confirm green**
+
+Run: `pnpm vitest run packages/shared/src/__tests__/outbox.unit.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Add the column to all seven schemas**
+
+In each of `services/{hello,inventory,order,payment,catalog,notification,identity}/prisma/schema.prisma`,
+add to `model Outbox` after the `traceId` line:
+
+```prisma
+  traceparent   String?
+```
+
+Then generate one migration per service — **CLI only**, hand-writing the migration file is
+blocked by a hook and breaks Prisma's checksums:
+
+```bash
+for s in hello inventory order payment catalog notification identity; do
+  DATABASE_URL="postgresql://ecom:ecom@localhost:5432/$s" \
+    pnpm --filter "@ecom/$s" exec prisma migrate dev --name add_traceparent_to_outbox
+done
+```
+
+If port 5432 is taken by another local stack, use the remapped port instead — see the
+Local infra note in Global Constraints.
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `pnpm vitest run packages/shared`
+Expected: PASS, all pre-existing shared tests unmodified.
+
+- [ ] **Step 7: Typecheck, format, commit**
+
+```bash
+pnpm -r typecheck && pnpm format:check
+git add packages/shared/src/outbox.ts packages/shared/src/__tests__/outbox.unit.test.ts \
+        services/*/prisma/schema.prisma services/*/prisma/migrations
+git commit -m "feat(shared,services): persist traceparent on the outbox row"
+```
+
+---
+
+### Task 5: Capture `traceparent` at every outbox write site
+
+**Files:**
+- Modify, all enumerated and verified — 10 sites across 8 files:
+  - `services/order/src/tx-adapters.ts` (2: inside `placeOrderTx` and `transitionTx`)
+  - `services/inventory/src/tx-adapters.ts:42`, `:86`
+  - `services/inventory/src/sweeper.ts:25`
+  - `services/payment/src/tx-adapters.ts:31`, `:68`
+  - `services/identity/src/tx-adapters.ts:51`
+  - `services/catalog/src/tx-adapters.ts:42`
+  - `services/notification/src/tx-adapters.ts:26`
+  - `services/hello/src/app.ts:41`
+- Test: `services/order/src/__tests__/outbox-traceparent.int.test.ts`
+
+**Interfaces:**
+- Consumes: `currentTraceparent()` from Task 3.
+
+Find every site first — do not trust this list to be exhaustive:
+
+```bash
+grep -rn "outbox.create" services --include="*.ts" | grep -v __tests__ | grep -v generated
+```
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, afterAll } from "vitest";
+import { context, trace, TraceFlags, type SpanContext } from "@opentelemetry/api";
+import { randomUUID } from "crypto";
+import { prisma } from "../db";
+import { placeOrderTx } from "../tx-adapters";
+
+const TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736";
+const SPAN_ID = "00f067aa0ba902b7";
+
+describe("outbox rows capture the active traceparent (integration)", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("writes the active span's context onto the row", async () => {
+    const orderId = `o_${randomUUID()}`;
+    const sc: SpanContext = {
+      traceId: TRACE_ID,
+      spanId: SPAN_ID,
+      traceFlags: TraceFlags.SAMPLED,
+      isRemote: false,
+    };
+    await context.with(trace.setSpanContext(context.active(), sc), async () => {
+      await prisma.$transaction(async (tx) => {
+        await placeOrderTx(tx, "t").enqueue("order.placed", orderId, {});
+      });
+    });
+    const row = await prisma.outbox.findFirst({ where: { aggregateId: orderId } });
+    expect(row?.traceparent).toBe(`00-${TRACE_ID}-${SPAN_ID}-01`);
+  });
+
+  it("writes null when there is no active span, rather than throwing", async () => {
+    const orderId = `o_${randomUUID()}`;
+    await prisma.$transaction(async (tx) => {
+      await placeOrderTx(tx, "t").enqueue("order.placed", orderId, {});
+    });
+    const row = await prisma.outbox.findFirst({ where: { aggregateId: orderId } });
+    expect(row?.traceparent).toBeNull();
+  });
+});
+```
+
+Named `.int.test.ts` because it imports the service's `db` and therefore its config —
+Global Constraint 7.
+
+- [ ] **Step 2: Run and confirm it fails**
+
+Run: `DATABASE_URL="postgresql://ecom:ecom@localhost:5432/order" pnpm vitest run services/order/src/__tests__/outbox-traceparent.int.test.ts`
+Expected: FAIL — `row.traceparent` is null in the first case.
+
+- [ ] **Step 3: Add the capture at each site**
+
+At the top of each modified file:
+
+```ts
+import { currentTraceparent } from "@ecom/shared";
+```
+
+And inside every `tx.outbox.create({ data: { … } })`, after the existing `traceId,` line:
+
+```ts
+          traceparent: currentTraceparent(),
+```
+
+`currentTraceparent()` returns `undefined` with no active span and Prisma stores that as
+`NULL` — so an untraced write (every unit test, any service started without the preload)
+is unaffected. It cannot throw: it only reads the active context.
+
+- [ ] **Step 4: Run and confirm green**
+
+Run: `DATABASE_URL="postgresql://ecom:ecom@localhost:5432/order" pnpm vitest run services/order`
+Expected: PASS, all pre-existing order tests unmodified.
+
+- [ ] **Step 5: Confirm no write site was missed**
+
+```bash
+grep -rn "outbox.create" services --include="*.ts" | grep -v __tests__ | grep -v generated | \
+  grep -L "traceparent" || echo "every site carries traceparent"
+```
+
+Re-read each hit and confirm it has the line. A missed site is a silently broken trace
+chain for that one event type, which no test will catch.
+
+- [ ] **Step 6: Typecheck, format, commit**
+
+```bash
+pnpm -r typecheck && pnpm format:check
+git add services/*/src/tx-adapters.ts services/inventory/src/sweeper.ts services/hello/src/app.ts \
+        services/order/src/__tests__/outbox-traceparent.int.test.ts
+git commit -m "feat(services): capture the active traceparent on every outbox write"
+```
+
+---
+
+### Task 6: Relay producer span + Kafka consumer span
+
+**Files:**
+- Modify: `packages/shared/src/outbox.ts`, `packages/shared/src/kafka.ts`
+- Test: `packages/shared/src/__tests__/tracing-seams.unit.test.ts`
+
+**Interfaces:**
+- Consumes: `OutboxRow.traceparent` (Task 4), `EventEnvelope.traceparent` (Task 1).
+- Produces: relayed envelopes whose `traceparent` is the **relay's** span, not the stored one.
+
+This is the task that makes the relay's polling delay visible, and the one whose test must
+discriminate — a counter-style test that only checks "a span exists" would pass against a
+broken implementation.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  NodeTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-node";
+import { drainOutbox, type OutboxPort } from "../outbox";
+import type { EventEnvelope } from "@ecom/contracts";
+
+const exporter = new InMemorySpanExporter();
+const provider = new NodeTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] });
+provider.register();
+
+const STORED = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+beforeEach(() => exporter.reset());
+
+function portWith(traceparent?: string): OutboxPort {
+  return {
+    async fetchUnsent() {
+      return [
+        {
+          id: "33333333-3333-4333-8333-333333333333",
+          aggregateType: "order",
+          aggregateId: "o1",
+          type: "order.placed",
+          version: 1,
+          traceId: "t",
+          traceparent,
+          producer: "order",
+          payload: {},
+          occurredAt: new Date(),
+          sentAt: null,
+        },
+      ];
+    },
+    async markSent() {},
+  };
+}
+
+describe("relay producer span", () => {
+  it("parents to the STORED context and republishes its OWN context", async () => {
+    const published: EventEnvelope[] = [];
+    await drainOutbox(portWith(STORED), { async publish(_t, e) { published.push(e); } }, () => "order.events");
+
+    const span = exporter.getFinishedSpans().find((s) => s.name.includes("order.events"));
+    expect(span).toBeDefined();
+    // Parented to the stored business span…
+    expect(span!.spanContext().traceId).toBe("4bf92f3577b34da6a3ce929d0e0e4736");
+    // The parent-span-id accessor moved between SDK majors (`parentSpanId` in v1,
+    // `parentSpanContext.spanId` in v2). Read whichever this version exposes rather than
+    // pinning one and having the test fail for a reason that is not the behaviour.
+    const parentSpanId =
+      (span as unknown as { parentSpanContext?: { spanId: string }; parentSpanId?: string })
+        .parentSpanContext?.spanId ??
+      (span as unknown as { parentSpanId?: string }).parentSpanId;
+    expect(parentSpanId).toBe("00f067aa0ba902b7");
+    // …but the PUBLISHED envelope carries the relay's own span, not the stored one.
+    // This is what lets the consumer parent to the relay and makes the poll gap visible.
+    expect(published[0].traceparent).not.toBe(STORED);
+    expect(published[0].traceparent).toContain(span!.spanContext().spanId);
+  });
+
+  it("starts a fresh trace when the stored traceparent is malformed, and does not throw", async () => {
+    const published: EventEnvelope[] = [];
+    await expect(
+      drainOutbox(portWith("not-a-traceparent"), { async publish(_t, e) { published.push(e); } }, () => "order.events")
+    ).resolves.toBeDefined();
+    expect(published).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run and confirm it fails**
+
+Run: `pnpm vitest run packages/shared/src/__tests__/tracing-seams.unit.test.ts`
+Expected: FAIL — no span is produced.
+
+- [ ] **Step 3: Add the producer span to the relay**
+
+In `packages/shared/src/outbox.ts`:
+
+```ts
+import { trace, context, propagation, SpanKind } from "@opentelemetry/api";
+
+const tracer = trace.getTracer("@ecom/shared/outbox");
+
+// Rebuild a context from the stored traceparent. Never throws: a malformed value from an
+// older or untrusted producer yields the active context, which starts a fresh trace.
+function contextFromRow(row: OutboxRow) {
+  try {
+    return row.traceparent
+      ? propagation.extract(context.active(), { traceparent: row.traceparent })
+      : context.active();
+  } catch {
+    return context.active();
+  }
+}
+```
+
+Then wrap the publish. Where `drainOutbox` currently does `await producer.publish(topic, envelope)`,
+replace with:
+
+```ts
+      const parent = contextFromRow(row);
+      await context.with(parent, async () => {
+        const span = tracer.startSpan(`${topic} publish`, { kind: SpanKind.PRODUCER });
+        try {
+          // Overwrite the OUTGOING envelope's traceparent with this span's context, so the
+          // consumer parents to the relay and the poll delay is visible as the gap between
+          // the business span ending and this one starting. The stored row is untouched —
+          // a replayed row still re-parents to the original business operation.
+          const carrier: Record<string, string> = {};
+          propagation.inject(trace.setSpan(context.active(), span), carrier);
+          const outgoing = carrier.traceparent
+            ? { ...envelope, traceparent: carrier.traceparent }
+            : envelope;
+          await producer.publish(topic, outgoing);
+        } finally {
+          span.end();
+        }
+      });
+```
+
+Apply the same shape to the command lane (`sender.sendCommand`), so the RabbitMQ leg —
+which is how the checkout reaches **payment** — is covered too. That leg is the one most
+easily missed, because the Kafka path is the one usually drawn.
+
+- [ ] **Step 4: Add the consumer span in kafka.ts**
+
+In `packages/shared/src/kafka.ts`, inside `eachMessage`, after the envelope parses and
+**around** the existing `withRetry(() => handler(env), …)` call:
+
+```ts
+            const parent = (() => {
+              try {
+                return env.traceparent
+                  ? propagation.extract(context.active(), { traceparent: env.traceparent })
+                  : context.active();
+              } catch {
+                return context.active();
+              }
+            })();
+            await context.with(parent, async () => {
+              const span = tracer.startSpan(`${topic} process`, { kind: SpanKind.CONSUMER });
+              span.setAttribute("messaging.message.id", env.eventId);
+              span.setAttribute("messaging.destination.name", topic);
+              try {
+                await withRetry(() => handler(env), { retries: maxRetries, baseMs: 200 });
+              } finally {
+                span.end();
+              }
+            });
+```
+
+Attributes are IDs only — never the payload (Global Constraint 9).
+
+Leave the existing metrics hooks and the DLQ catch **exactly** as they are. The span must
+never change whether a message is parked: it wraps only the handler call, inside the
+existing try.
+
+- [ ] **Step 5: Run and confirm green**
+
+Run: `pnpm vitest run packages/shared`
+Expected: PASS — new seam tests plus every pre-existing shared test unmodified, including
+`kafka-hooks.unit.test.ts` and both kafka integration suites.
+
+- [ ] **Step 6: Prove the consumer seam discriminates**
+
+Delete the `propagation.extract` line in `kafka.ts` (make it always `context.active()`),
+re-run, and confirm a test fails. Restore. Record which test failed in the task report —
+a seam test that passes with the wiring removed is worthless, and this slice has three of them.
+
+- [ ] **Step 7: Typecheck, format, commit**
+
+```bash
+pnpm -r typecheck && pnpm format:check
+git add packages/shared/src/outbox.ts packages/shared/src/kafka.ts \
+        packages/shared/src/__tests__/tracing-seams.unit.test.ts
+git commit -m "feat(shared): relay producer spans and kafka consumer spans"
+```
+
+---
+
+### Task 7: RabbitMQ command seam
+
+**Files:**
+- Modify: `packages/shared/src/rabbitmq.ts`
+- Test: `packages/shared/src/__tests__/tracing-rabbit.unit.test.ts`
+
+**Interfaces:**
+- Consumes: `EventEnvelope.traceparent` (Task 1).
+
+`sendCommand` (`rabbitmq.ts:77`) and `consumeCommands` (`:88`) carry the
+`ChargePayment` leg — gateway → order → **payment**. Without this task the Done-when
+cannot be met, however good the Kafka path is.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  NodeTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-node";
+import { makeEnvelope } from "@ecom/contracts";
+import { consumerContextFor } from "../rabbitmq";
+
+const exporter = new InMemorySpanExporter();
+new NodeTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] }).register();
+
+const TP = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+beforeEach(() => exporter.reset());
+
+describe("rabbit consumer context", () => {
+  it("extracts the envelope's traceparent as the parent", () => {
+    const env = makeEnvelope({
+      type: "payment.charge", version: 1, traceId: "t",
+      producer: "order", payload: {}, traceparent: TP,
+    });
+    const ctx = consumerContextFor(env);
+    const { trace, context } = require("@opentelemetry/api");
+    expect(trace.getSpanContext(ctx)!.traceId).toBe("4bf92f3577b34da6a3ce929d0e0e4736");
+  });
+
+  it("returns the active context — not a throw — for a malformed traceparent", () => {
+    const env = makeEnvelope({
+      type: "payment.charge", version: 1, traceId: "t",
+      producer: "order", payload: {}, traceparent: "garbage",
+    });
+    expect(() => consumerContextFor(env)).not.toThrow();
+  });
+
+  it("returns the active context when there is no traceparent at all", () => {
+    const env = makeEnvelope({
+      type: "payment.charge", version: 1, traceId: "t", producer: "order", payload: {},
+    });
+    expect(() => consumerContextFor(env)).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run and confirm it fails**
+
+Run: `pnpm vitest run packages/shared/src/__tests__/tracing-rabbit.unit.test.ts`
+Expected: FAIL — `consumerContextFor` is not exported.
+
+- [ ] **Step 3: Implement**
+
+In `packages/shared/src/rabbitmq.ts`:
+
+```ts
+import { trace, context, propagation, SpanKind } from "@opentelemetry/api";
+
+const tracer = trace.getTracer("@ecom/shared/rabbitmq");
+
+// Exported for the unit test: the extraction is the part that can silently regress.
+export function consumerContextFor(env: EventEnvelope) {
+  try {
+    return env.traceparent
+      ? propagation.extract(context.active(), { traceparent: env.traceparent })
+      : context.active();
+  } catch {
+    return context.active();
+  }
+}
+```
+
+Wrap the handler call inside `consumeCommands` the same way Task 6 wrapped the Kafka
+handler — a `${queue} process` span of kind `CONSUMER`, started inside
+`context.with(consumerContextFor(env), …)`, ended in a `finally`, with the existing retry
+and DLQ behaviour untouched.
+
+`sendCommand` already receives an envelope whose `traceparent` the relay set in Task 6, so
+it needs no change beyond a `${queue} send` PRODUCER span if one is wanted; the parenting
+is already correct without it.
+
+- [ ] **Step 4: Run and confirm green**
+
+Run: `pnpm vitest run packages/shared`
+Expected: PASS, including `rabbitmq.int.test.ts` unmodified.
+
+- [ ] **Step 5: Typecheck, format, commit**
+
+```bash
+pnpm -r typecheck && pnpm format:check
+git add packages/shared/src/rabbitmq.ts packages/shared/src/__tests__/tracing-rabbit.unit.test.ts
+git commit -m "feat(shared): rabbit consumer spans parented to the envelope context"
+```
+
+---
+
+### Task 8: Jaeger in compose, preload wiring, docs
+
+**Files:**
+- Modify: `docker-compose.example.yml`, `docker-compose.prod.example.yml`, `docs/infra.md`
+
+**Interfaces:**
+- Consumes: `packages/shared/src/tracing.ts` (Task 2).
+
+- [ ] **Step 1: Check the UI port is free**
+
+```bash
+docker ps --format "{{.Names}}\t{{.Ports}}" | grep -E "16686" || echo "16686 free"
+```
+
+This machine's unrelated `eda-platform` stack already collides on 5432, 9090, 4318 and
+1025/8025. If 16686 is taken, use a host remap and note it — do not stop the other stack.
+
+- [ ] **Step 2: Add Jaeger**
+
+In `docker-compose.example.yml`, beside the `prometheus` and `grafana` entries added in 7b:
+
+```yaml
+  jaeger:
+    image: jaegertracing/all-in-one:1.62.0
+    restart: unless-stopped
+    ports: ["16686:16686"]   # UI only — OTLP stays in-network, like the gateway's metrics port
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:14269/"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+```
+
+Ports 4317/4318 are deliberately **not** published: services reach `jaeger:4318` over the
+compose network, so nothing on the host can post spans.
+
+- [ ] **Step 3: Wire the preload into all 8 services**
+
+To each service's `environment:` block in `docker-compose.example.yml`:
+
+```yaml
+      OTEL_SERVICE_NAME: <service-name>
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4318
+      NODE_OPTIONS: --import tsx --import file:///repo/packages/shared/src/tracing.ts
+```
+
+The `file://` URL and the `--import tsx` ordering are both load-bearing and were verified
+by experiment — a bare specifier fails with `ERR_MODULE_NOT_FOUND` because
+`@ecom/shared` has no `exports` map, and the bootstrap is a `.ts` file so tsx's loader must
+be registered first. `/repo/packages/shared/src/tracing.ts` is correct in all 8 containers:
+every Dockerfile does `WORKDIR /repo` → `COPY packages ./packages`.
+
+- [ ] **Step 4: Prod overlay**
+
+In `docker-compose.prod.example.yml`, beside the prometheus and grafana entries:
+
+```yaml
+  jaeger:
+    ports: !reset []
+```
+
+A bare `[]` silently merges and does nothing — `!reset` is required.
+
+- [ ] **Step 5: Document**
+
+In `docs/infra.md`, add to the endpoint table:
+
+```
+| Jaeger     | http://localhost:16686  | traces; needs `--profile app` |
+```
+
+Plus a short paragraph: traces are exported to `jaeger:4318` in-network and the OTLP ports
+are unpublished; a `traceId` from any log line is the Jaeger search term.
+
+- [ ] **Step 6: Validate**
+
+```bash
+docker compose -f docker-compose.example.yml config >/dev/null && echo "compose valid"
+docker compose -f docker-compose.example.yml -f docker-compose.prod.example.yml --profile app config \
+  | python3 -c "import sys,yaml; c=yaml.safe_load(sys.stdin); print('jaeger prod ports:', c['services']['jaeger'].get('ports','(none)'))"
+```
+
+Expected: valid, and jaeger's prod ports resolve to none.
+
+- [ ] **Step 7: Commit**
+
+```bash
+pnpm format:check
+git add docker-compose.example.yml docker-compose.prod.example.yml docs/infra.md
+git commit -m "feat(infra): jaeger all-in-one and the tracing preload wiring"
+```
+
+---
+
+### Task 9: End-to-end acceptance
+
+**Files:**
+- Create: `.superpowers/sdd/2026-07-29-phase-7c-tracing/acceptance.md` (evidence, not code)
+
+**Interfaces:**
+- Consumes: every prior task.
+
+The spec's Done-when is the acceptance test. 7b proved this step earns its keep: running it
+found a dashboard panel that rendered "No data" for every healthy service, which no amount
+of static review had caught.
+
+- [ ] **Step 1: Bring the stack up**
+
+```bash
+bash infra/scripts/reset-dev-topics.sh
+docker compose --profile app up -d --build
+docker compose ps    # every service healthy
+```
+
+- [ ] **Step 2: Confirm spans are arriving**
+
+Open `http://localhost:16686` and confirm the service dropdown lists the traced services.
+
+- [ ] **Step 3: Drive a real checkout**
+
+Through the gateway on :8000 — register → login → add to cart → place order. Three details
+that cost time in 7b: register requires a `name` field, every mutation needs the
+double-submit CSRF header (echo the `XSRF-TOKEN` cookie into `x-csrf-token`), and the cart is
+its own gateway mount (`/cart`, not `/orders/cart`). Inventory needs a stock row for the
+product, and `Inventory.updatedAt` is NOT NULL with no default.
+
+- [ ] **Step 4: Verify the Done-when**
+
+In Jaeger, find the trace and confirm **all** of:
+
+- One trace spans gateway → order → inventory → payment → notification.
+- The **payment** hop is present — it travels over RabbitMQ, so its absence means Task 7 is
+  not wired even if everything else looks right.
+- A gap is visible between a business span ending and the next `publish` span starting —
+  that is the relay poll delay, and its visibility is the point of the whole design.
+- The `traceId` from the order service's log line for that order finds this exact trace.
+
+- [ ] **Step 5: Measure the idle span floor**
+
+With the stack up and no traffic, note the span rate over one minute. Seven relays poll
+every 500ms and the DLQ poller every 15s, so there is a standing floor independent of
+requests. Record the number — 7d needs it to choose a sampling ratio, and it is far cheaper
+to measure now than under k6 load.
+
+- [ ] **Step 6: Record the evidence**
+
+Write `acceptance.md` with: the trace screenshot or span list, the measured idle span rate,
+which services appeared, and anything that did not work. Note explicitly that `hello`'s
+container CrashLoops on a pre-existing corepack issue (`services/hello/Dockerfile` is
+untouched by 7b and 7c), so its spans cannot be verified in-container — the same limitation
+its Prometheus target has.
+
+- [ ] **Step 7: Full regression**
+
+```bash
+pnpm -r typecheck && pnpm format:check
+# per-service, because each has its own database — a single DATABASE_URL cannot work
+for s in hello inventory order payment catalog notification identity gateway; do
+  DATABASE_URL="postgresql://ecom:ecom@localhost:5432/$s" pnpm vitest run "services/$s"
+done
+pnpm vitest run packages
+```
+
+Expected: all 356 pre-existing tests pass **unmodified**, plus the new ones.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add .superpowers/sdd/2026-07-29-phase-7c-tracing/acceptance.md
+git commit -m "docs(7c): end-to-end tracing acceptance evidence"
+```
+
+---
+
+## Notes for the executor
+
+**Task order is dependency order.** 1 → 2 → 3 must be sequential (contract, then bootstrap,
+then `currentTraceparent`). 4 and 5 both depend on 3. 6 and 7 both depend on 4. 8 depends on
+2. 9 depends on everything.
+
+**The three discriminating tests** are Task 5 Step 5, Task 6 Step 6, and Task 9 Step 4. Each
+exists because the corresponding naive test would pass against a broken implementation. If
+one of them cannot be made to fail by removing the wiring it is meant to protect, say so in
+the task report rather than moving on — that is a finding, not a formality.
+
+**When a task's brief and the Global Constraints disagree, the constraints win.** Both 7a
+and 7b had a plan snippet that omitted a try/catch the constraints already required, and
+both were adjudicated the same way.

--- a/docs/superpowers/plans/2026-07-29-phase-7c-tracing.md
+++ b/docs/superpowers/plans/2026-07-29-phase-7c-tracing.md
@@ -151,10 +151,12 @@ anything from shared.
 
 ```bash
 pnpm --filter @ecom/shared add @opentelemetry/api @opentelemetry/sdk-node \
-  @opentelemetry/auto-instrumentations-node @opentelemetry/exporter-trace-otlp-http \
-  @opentelemetry/instrumentation-redis @opentelemetry/resources \
-  @opentelemetry/semantic-conventions
+  @opentelemetry/exporter-trace-otlp-http @opentelemetry/instrumentation-http \
+  @opentelemetry/instrumentation-express @opentelemetry/instrumentation-redis \
+  @opentelemetry/resources @opentelemetry/semantic-conventions
 pnpm --filter @ecom/shared add @prisma/instrumentation@^6.19
+# Test-only: Tasks 6 and 7 assert on spans with an in-memory exporter, which lives here.
+pnpm --filter @ecom/shared add -D @opentelemetry/sdk-trace-node
 ```
 
 Verify `@prisma/instrumentation` resolved to a 6.x, not 7.x:
@@ -163,14 +165,20 @@ Verify `@prisma/instrumentation` resolved to a 6.x, not 7.x:
 - [ ] **Step 2: Write the failing test**
 
 ```ts
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 describe("tracing bootstrap", () => {
   it("is idempotent — a second evaluation does not start a second SDK", async () => {
     const first = await import("../tracing");
     expect(first.tracingStarted()).toBe(true);
-    // Re-import with a busted module cache, the way the tsx loader re-evaluates it.
-    const second = await import(`../tracing?reload=${Date.now()}`);
+
+    // Re-evaluate the module with a cleared registry — this is what the tsx loader
+    // does, and it is the case a module-local flag would fail to guard. Use
+    // vi.resetModules(), NOT an `import("../tracing?query")` cache-buster: vitest
+    // resolves that through its own transform pipeline and it does not reliably
+    // produce a second evaluation.
+    vi.resetModules();
+    const second = await import("../tracing");
     expect(second.tracingStarted()).toBe(true);
     expect(globalThis.__ecomTracingStarted__).toBe(true);
   });

--- a/docs/superpowers/specs/2026-07-29-phase-7c-tracing-design.md
+++ b/docs/superpowers/specs/2026-07-29-phase-7c-tracing-design.md
@@ -79,9 +79,11 @@ The same experiment showed the preload module is evaluated **more than once** un
 once per loader thread plus once on the main thread. A bootstrap that calls `sdk.start()`
 unconditionally would therefore register duplicate exporters and duplicate instrumentations.
 
-`tracing.ts` guards on a module-level flag stored on `globalThis`, so that repeat evaluations
-in separate module registries still see the first one's mark. A unit test asserts a second
-evaluation is a no-op.
+`tracing.ts` guards on a flag stored on `globalThis`. It must be `globalThis` and not a
+module-local boolean: the repeat evaluations happen in **separate module registries**, where a
+module-local flag is a fresh `false` every time and guards nothing. A unit test asserts a second
+evaluation is a no-op — and the reason is written here because the obvious "simplification" back
+to a module-scoped variable would pass review and silently restore the bug.
 
 **Consequence, deliberate:** a service run bare on the host — every test, every ad-hoc
 `pnpm dev` — has no `NODE_OPTIONS` and therefore exports no spans. That is the correct
@@ -96,8 +98,8 @@ enabled set is explicit, not default:
 | Instrumentation | State | Why |
 |---|---|---|
 | `http`, `express` | **on** | The sync seam: gateway → service, and the gateway's own proxy hops. |
-| `@prisma/instrumentation` | **on** | Prisma's query engine does **not** go through node-postgres, so `instrumentation-pg` sees nothing. Prisma needs its own instrumentation to emit query spans. |
-| `redis-4` | **on** | Inventory's distributed lock is a real latency source worth seeing. Note the client is node-redis (`redis@^4.7.0`, `packages/shared/src/redis.ts:1`), **not** ioredis — they need different instrumentations and the wrong one silently emits nothing. |
+| `@prisma/instrumentation@^6.19` | **on** | Prisma's query engine does **not** go through node-postgres, so `instrumentation-pg` sees nothing. Prisma needs its own instrumentation to emit query spans. **Pin the 6.x line**: latest is 7.9.1, but every service pins `@prisma/client: ^6.1.0`, and this package tracks Prisma's major — so it is an upgrade-in-lockstep dependency, not a free-floating one. |
+| `@opentelemetry/instrumentation-redis` | **on** | Inventory's distributed lock is a real latency source worth seeing. Two naming traps here, both checked against npm rather than assumed: the client is node-redis (`redis@^4.7.0`, `packages/shared/src/redis.ts:1`) and **not** ioredis, and the once-correct `instrumentation-redis-4` is now **deprecated** in favour of `instrumentation-redis`, which covers v4+. The wrong package in either direction installs cleanly and silently emits nothing. |
 | `kafkajs`, `amqplib` | **OFF** | Load-bearing decision — see A3. |
 | `fs`, `dns`, `net` | **off** | Noise. `fs` in particular buries a trace in hundreds of spans. |
 
@@ -124,7 +126,11 @@ All standard OTel env vars, no bespoke config schema:
 - `OTEL_SERVICE_NAME` — set per service in compose; becomes the Jaeger service name.
 - `OTEL_EXPORTER_OTLP_ENDPOINT` — `http://jaeger:4318`, OTLP over HTTP.
 - `OTEL_TRACES_SAMPLER` — `parentbased_always_on` by default. 7d will lower this under k6
-  load; making it an env var now means 7d needs no code change.
+  load; making it an env var now means 7d needs no code change. Note there is a **standing
+  span floor** independent of request traffic: seven outbox relays poll every 500ms and the
+  DLQ poller every 15s, so an idle stack still emits spans continuously. Task 1 should record
+  the idle span rate — it is the number 7d needs to pick a sampling ratio, and it is far
+  cheaper to measure now than under load.
 - Absent `NODE_OPTIONS`, none of this is read at all.
 
 ---
@@ -179,13 +185,26 @@ with `.partial({ userId: true })` or they would retry 3× and dead-letter foreve
 `traceparent` would do exactly that to every event in flight during the 7c deploy.
 
 Broker headers were the alternative and were rejected: this system round-trips events through
-places headers do not survive. The `Outbox` row is JSON in Postgres. The DLQ park path
-republishes the **raw value** (`kafka.ts:117`). `moveDlqOnce` replays that raw value. Putting
-the context inside the envelope makes it survive all three for free; putting it in headers
-means adding and maintaining header plumbing on each of those paths.
+three places headers do not survive, and the three differ from each other:
 
-Every `Outbox` table gains a nullable `traceparent String?` column — seven migrations, one
-per outbox-owning service (all but gateway, which has no database).
+- The `Outbox` row is **JSON in Postgres** — there is no header channel at all.
+- The Kafka DLQ park republishes the **raw bytes** (`kafka.ts:117`), so anything not inside
+  those bytes is gone.
+- `moveDlqOnce` **re-parses through the schema** — `EventEnvelopeSchema.parse(JSON.parse(...))`
+  at `rabbitmq.ts:137` — so it round-trips declared fields and drops everything else.
+
+The envelope survives all three for free. Headers survive none of them, and the third case is
+the subtle one: a header-based design would look correct right up until a message went through
+DLQ replay, which is exactly when an operator most wants the trace.
+
+`makeEnvelope` (`packages/shared/src/outbox.ts:39-49`) is the **only** constructor on the relay
+path, so its input type gains `traceparent` too. A change to the schema that misses the builder
+would leave the field declared and never populated — the failure mode this note exists to
+prevent.
+
+Every `Outbox` table gains a nullable `traceparent String?` column — **seven** migrations, one
+per outbox-owning service. Verified: hello, inventory, order, payment, catalog, notification and
+identity each declare `model Outbox`; gateway has no `prisma/` directory and no database.
 
 ### C3. Span shape across the seam
 
@@ -209,6 +228,19 @@ Three properties this buys, each of which is the point:
    the original business operation, not to a previous replay.
 3. A consumer that writes its own outbox row repeats the pattern, so the chain extends
    through the full saga without special-casing any hop.
+
+**Both brokers, not just Kafka.** The diagram shows the Kafka hop, but the Done-when's
+`…→ payment →…` leg travels over **RabbitMQ** (`ChargePayment` on the `payment.charge` work
+queue), so `rabbitmq.ts`'s `sendCommand`/`consumeCommands` get the identical treatment. The
+Rabbit path is the one most likely to be skipped precisely because it is not the one drawn.
+
+**Replay re-parents to the original, deliberately.** Because the stored row keeps the business
+span's context, a row replayed days later joins the *original* trace rather than starting a
+fresh one. This is the intended behaviour — the causal question "what did this order do" stays
+answerable — but it has a consequence worth stating: the sibling spans may already have aged out
+of Jaeger's retention, so a replayed message can land in a trace that renders nearly empty. The
+alternative (re-root on replay) loses the causal link permanently, which is the worse trade for
+a system whose whole DLQ story is "replay it later".
 
 ### C4. Failure behaviour
 
@@ -234,7 +266,9 @@ justifies it.
 
 - `4317`/`4318` (OTLP) are reached **in-network** at `jaeger:4318` and are deliberately **not
   published** to the host — same posture as the gateway's metrics port in 7b.
-- `16686` (UI) is published.
+- `16686` (UI) is published. Check it is free before assuming: this machine's unrelated
+  `eda-platform` stack already collides with the ecom stack on 5432, 9090, 4318 and 1025/8025,
+  and 7b had to remap three of those. 16686 has not been checked.
 - Prod overlay resets the UI port with `!reset []`, like every other operator-facing surface.
 - `docs/infra.md` gains the endpoint row and the `--profile app` note that already applies to
   Prometheus and Grafana.

--- a/docs/superpowers/specs/2026-07-29-phase-7c-tracing-design.md
+++ b/docs/superpowers/specs/2026-07-29-phase-7c-tracing-design.md
@@ -1,0 +1,303 @@
+# Phase 7c · OpenTelemetry traces & Jaeger — Design (child spec)
+
+> Phase 7 (Hardening, XL) is decomposed into four slices — 7a correctness & hygiene debt
+> (done, merged), 7b metrics & dashboards (done, merged at `4879c2f`), **7c tracing**
+> (this doc), 7d verification (k6 + chaos). See
+> `docs/superpowers/specs/2026-07-23-phases-3-8-roadmap.md` §Phase 7 for the slice model and
+> `docs/superpowers/specs/2026-07-28-phase-7b-metrics-design.md` for the sibling slice whose
+> shared-module-then-adopt shape this one deliberately copies.
+
+## Purpose
+
+7b answered "is the system healthy?" — rates, errors, durations, saga latency in aggregate.
+It cannot answer "what happened to **this** order?". A checkout crosses gateway → order →
+inventory → payment → notification through two brokers and seven outboxes; today the only
+thread tying those together is a uuid `traceId` that a human greps for across seven log
+streams.
+
+7c makes that thread machine-readable. One checkout becomes one Jaeger trace, with a span per
+hop and — critically — **visible gaps** where the system is waiting rather than working.
+
+The roadmap's Done-when for this slice is exact: *one Jaeger trace spans
+gateway→order→inventory→payment→notification*. That sentence is the acceptance test, and it
+is what forces the hard part below.
+
+## Scope
+
+**In:**
+
+- A shared tracing bootstrap in `packages/shared`, loaded as a Node `--import` preload.
+- Auto-instrumentation for HTTP, Express and Prisma; **manual** spans for the messaging seams.
+- `traceparent` on `EventEnvelope` (optional) and on every `Outbox` table.
+- Producer spans in the outbox relay; consumer spans in the Kafka and RabbitMQ adapters.
+- `traceId` re-based onto the W3C trace ID, with `x-trace-id` kept as a compatibility alias.
+- Jaeger all-in-one in compose, plus `docs/infra.md`.
+
+**Out:**
+
+- Metrics/exemplar linkage between Prometheus and Jaeger (7d, once there is load worth
+  sampling from).
+- Log→trace correlation beyond emitting `traceId` — no log shipper, no Loki.
+- k6, chaos, SLO burn alerts — all 7d.
+- Any business-logic change. As in 7b, every pre-existing test must pass unmodified.
+
+---
+
+## A. The shared tracing module
+
+### A1. Bootstrap by preload, not by import
+
+The SDK must patch `http`, `express` and Prisma **before** those modules are loaded. Every
+service's container CMD is `pnpm exec tsx src/main.ts`, and ESM hoists imports — so a
+`startTracing()` call at the top of `main.ts` would run *after* the modules it needs to patch.
+
+`packages/shared/src/tracing.ts` therefore exports a side-effecting bootstrap, loaded via:
+
+```
+NODE_OPTIONS=--import tsx --import file:///repo/packages/shared/src/tracing.ts
+```
+
+set per service in `docker-compose.example.yml`. Dockerfiles and CMDs are untouched.
+
+**This exact form was verified empirically, not assumed** — three findings, each of which
+would otherwise have been discovered during implementation:
+
+1. **A bare specifier does not resolve.** `--import @ecom/shared/tracing` fails with
+   `ERR_MODULE_NOT_FOUND`, because `packages/shared/package.json` has no `exports` map and
+   its `main` is `src/index.ts`. Adding an `exports` map to satisfy the preload would change
+   how all eight services resolve the package — a far larger blast radius than the preload
+   itself justifies. A `file://` URL sidesteps it entirely.
+2. **`--import tsx` must come first.** The bootstrap is a `.ts` file, so tsx's ESM loader has
+   to be registered before Node tries to load it. Node preserves `--import` order.
+3. **The absolute path is stable and knowable.** Every service Dockerfile does
+   `WORKDIR /repo` → `COPY packages ./packages` → `WORKDIR /repo/services/<svc>`, so
+   `/repo/packages/shared/src/tracing.ts` is correct in all eight containers.
+
+### A1a. The bootstrap must be idempotent
+
+The same experiment showed the preload module is evaluated **more than once** under tsx —
+once per loader thread plus once on the main thread. A bootstrap that calls `sdk.start()`
+unconditionally would therefore register duplicate exporters and duplicate instrumentations.
+
+`tracing.ts` guards on a module-level flag stored on `globalThis`, so that repeat evaluations
+in separate module registries still see the first one's mark. A unit test asserts a second
+evaluation is a no-op.
+
+**Consequence, deliberate:** a service run bare on the host — every test, every ad-hoc
+`pnpm dev` — has no `NODE_OPTIONS` and therefore exports no spans. That is the correct
+default: tests must not ship telemetry to a collector that may not exist. Tests that need to
+assert on spans start their own SDK with an in-memory exporter (§F).
+
+### A2. Which instrumentations are enabled
+
+`@opentelemetry/auto-instrumentations-node` bundles far more than this system wants. The
+enabled set is explicit, not default:
+
+| Instrumentation | State | Why |
+|---|---|---|
+| `http`, `express` | **on** | The sync seam: gateway → service, and the gateway's own proxy hops. |
+| `@prisma/instrumentation` | **on** | Prisma's query engine does **not** go through node-postgres, so `instrumentation-pg` sees nothing. Prisma needs its own instrumentation to emit query spans. |
+| `redis-4` | **on** | Inventory's distributed lock is a real latency source worth seeing. Note the client is node-redis (`redis@^4.7.0`, `packages/shared/src/redis.ts:1`), **not** ioredis — they need different instrumentations and the wrong one silently emits nothing. |
+| `kafkajs`, `amqplib` | **OFF** | Load-bearing decision — see A3. |
+| `fs`, `dns`, `net` | **off** | Noise. `fs` in particular buries a trace in hundreds of spans. |
+
+### A3. Why the messaging auto-instrumentations are disabled
+
+This is the single most important decision in the slice, and getting it wrong produces
+traces that look plausible and are wrong.
+
+The kafkajs and amqplib instrumentations propagate context through **broker headers** and
+create their own producer/consumer spans. This system propagates through the **envelope
+JSON** (§C). Enabling both means two competing mechanisms: two producer spans per publish,
+and a consumer span whose parent is chosen by whichever mechanism the instrumentation
+consulted first. Worse, the header-based one would silently win on the sync path and silently
+lose across the outbox — producing a trace that is correct for simple hops and subtly broken
+for exactly the async hops this slice exists to fix.
+
+The messaging seams are owned manually, in `kafka.ts` and `rabbitmq.ts`, where the envelope
+already is.
+
+### A4. Configuration
+
+All standard OTel env vars, no bespoke config schema:
+
+- `OTEL_SERVICE_NAME` — set per service in compose; becomes the Jaeger service name.
+- `OTEL_EXPORTER_OTLP_ENDPOINT` — `http://jaeger:4318`, OTLP over HTTP.
+- `OTEL_TRACES_SAMPLER` — `parentbased_always_on` by default. 7d will lower this under k6
+  load; making it an env var now means 7d needs no code change.
+- Absent `NODE_OPTIONS`, none of this is read at all.
+
+---
+
+## B. Trace identity and the HTTP seam
+
+### B1. One ID, W3C format
+
+`traceId` stops being a minted uuid and becomes the **OTel trace ID** — 32 lowercase hex, no
+dashes. A `traceId` in a log line pastes directly into Jaeger's search box.
+
+`packages/shared/src/trace.ts` is rewritten:
+
+- `traceMiddleware` no longer calls `uuidv4()`. It reads the active span context — which the
+  http/express instrumentation has already established, including extracting an inbound
+  `traceparent` — and assigns `req.traceId = span.spanContext().traceId`.
+- `TRACE_HEADER` (`x-trace-id`) is still read and still echoed on the response, so external
+  callers and the existing e2e tests keep working. On the way in it is now a **fallback**:
+  standard `traceparent` wins when both are present.
+- If there is no active span at all — the untraced case, i.e. every test run — the middleware
+  falls back to `uuidv4()` exactly as today. Nothing that works now stops working.
+
+### B2. The compatibility surface
+
+`EventEnvelopeSchema.traceId` stays `z.string().min(1)`. It is not tightened to 32-hex,
+because fixtures across the suite pass `traceId: "t"` and tightening it would be a
+test-rewriting exercise with no runtime benefit. The bridge in §C tolerates a non-conforming
+`traceId` by starting a fresh trace rather than throwing.
+
+---
+
+## C. Async propagation — the hard part
+
+### C1. Why a new field is needed at all
+
+`traceId` alone is insufficient. W3C `traceparent` is
+`version-traceid-spanid-flags`; the trace ID identifies the *trace*, the span ID identifies
+the *parent within it*. Carrying only the trace ID would put every span in one flat trace with
+no causality — a list, not a tree.
+
+### C2. The carrier is the envelope, not broker headers
+
+`EventEnvelopeSchema` gains:
+
+```ts
+traceparent: z.string().optional(),
+```
+
+**Optional, not required.** The codebase already paid for this lesson: when `ChargePayment`
+gained `userId`, in-flight commands minted under the narrower contract had to be tolerated
+with `.partial({ userId: true })` or they would retry 3× and dead-letter forever. A required
+`traceparent` would do exactly that to every event in flight during the 7c deploy.
+
+Broker headers were the alternative and were rejected: this system round-trips events through
+places headers do not survive. The `Outbox` row is JSON in Postgres. The DLQ park path
+republishes the **raw value** (`kafka.ts:117`). `moveDlqOnce` replays that raw value. Putting
+the context inside the envelope makes it survive all three for free; putting it in headers
+means adding and maintaining header plumbing on each of those paths.
+
+Every `Outbox` table gains a nullable `traceparent String?` column — seven migrations, one
+per outbox-owning service (all but gateway, which has no database).
+
+### C3. Span shape across the seam
+
+```
+order HTTP span                    (SERVER)
+  └─ business tx  ── writes Outbox row, traceparent = THIS span's context
+                                   ← row sits until the relay polls (≤500ms)
+relay publish span                 (PRODUCER)  parent = stored context
+  └─ injects ITS OWN context as the published envelope's traceparent
+inventory consume span             (CONSUMER)  parent = relay's producer span
+  └─ prisma spans, next Outbox row, …
+```
+
+Three properties this buys, each of which is the point:
+
+1. **The relay's polling delay is visible** as the gap between the business span ending and
+   the producer span starting. Today that latency is invisible; it is also the single largest
+   contributor to end-to-end checkout time.
+2. **The row at rest keeps the original context.** The relay overwrites `traceparent` only on
+   the envelope it publishes, never on the stored row. A replayed row therefore re-parents to
+   the original business operation, not to a previous replay.
+3. A consumer that writes its own outbox row repeats the pattern, so the chain extends
+   through the full saga without special-casing any hop.
+
+### C4. Failure behaviour
+
+Every constraint 7b established carries over verbatim, because this slice touches the same
+production paths:
+
+- **Nothing may throw into a production path.** Span creation, context injection and context
+  extraction are each wrapped and log-and-continue on failure. A malformed `traceparent` from
+  an untrusted or older producer starts a fresh trace; it never rejects the message.
+- Recording happens **after** the transaction resolves, never inside the tx callback — the
+  same placement rule that governs the 7b metrics, for the same reason.
+- The DLQ and retry paths keep their exact current behaviour. A span must never be the reason
+  a message is or is not parked.
+
+---
+
+## D. Compose and `infra/`
+
+Jaeger **all-in-one**, pinned (no `:latest` — same reasoning as the 7b dashboard), accepting
+OTLP natively so there is no separate Collector to run or configure. A Collector buys
+pipeline processing this system has no use for yet; it can be introduced in 7d if k6 volume
+justifies it.
+
+- `4317`/`4318` (OTLP) are reached **in-network** at `jaeger:4318` and are deliberately **not
+  published** to the host — same posture as the gateway's metrics port in 7b.
+- `16686` (UI) is published.
+- Prod overlay resets the UI port with `!reset []`, like every other operator-facing surface.
+- `docs/infra.md` gains the endpoint row and the `--profile app` note that already applies to
+  Prometheus and Grafana.
+
+Adding Jaeger as a Grafana datasource is explicitly **out**: it is 7d's job, once there are
+exemplars worth clicking through from a metrics panel.
+
+---
+
+## E. Decisions
+
+| # | Decision | Why |
+|---|---|---|
+| 1 | Hybrid: auto for plumbing, manual for messaging | Auto cannot bridge the outbox; manual everywhere is a needlessly wide diff. |
+| 2 | `traceId` **becomes** the W3C trace ID | One identifier. A log line pastes into Jaeger. The alternative is a permanent join. |
+| 3 | `traceparent` travels in the **envelope** | Survives the outbox row, the DLQ raw park, and replay — three paths headers do not. |
+| 4 | `traceparent` is **optional** | A required field dead-letters every event in flight during deploy. Precedent: `ChargePayment.userId`. |
+| 5 | Bootstrap via `NODE_OPTIONS=--import` | Works with tsx's ESM loader; leaves 8 Dockerfiles and CMDs untouched. |
+| 6 | kafkajs + amqplib auto-instrumentation **off** | Two competing propagation mechanisms produce traces that are right on sync hops and wrong on async ones. |
+| 7 | Jaeger all-in-one, no Collector | OTLP-native; a Collector adds a container and config for no current payoff. |
+| 8 | OTLP ports unpublished; only the UI is exposed | Same posture as 7b's separate metrics port. |
+| 9 | Sampling via `OTEL_TRACES_SAMPLER` env | 7d changes sampling without a code change. |
+
+---
+
+## F. Testing
+
+The lesson 7b ended on governs this section: **a test that constructs the machinery proves
+nothing about whether the call site is wired.** Every seam gets a test that fails if the
+wiring is removed.
+
+- **Bootstrap** — unit: the enabled-instrumentation set is exactly §A2's list, asserted by
+  name. This is the test that fails the day someone swaps in the full auto set and silently
+  re-enables kafkajs. A second unit test asserts re-evaluating the module is a no-op (§A1a).
+- **`traceMiddleware`** — unit: derives `traceId` from an active span context; falls back to a
+  uuid with no active span; prefers `traceparent` over `x-trace-id` when both are present.
+- **Envelope round-trip** — unit: an envelope with no `traceparent` parses (the deploy-safety
+  property), and a malformed `traceparent` yields a fresh trace rather than a throw.
+- **Outbox relay** — integration: a row written under an active span carries that context;
+  the published envelope's `traceparent` is the **relay's** span, not the stored one; the
+  stored row is unchanged. Run with an in-memory span exporter, no Jaeger required.
+- **Consumer seam** — integration, and this is the discriminating one: a message whose
+  envelope carries a `traceparent` produces a consumer span whose parent is that context.
+  Deleting the extraction call must fail this test while every other test stays green.
+- **Full-suite regression** — all 356 tests from the 7b merge pass **unmodified**.
+- **CI** — no new job. The `quality` lane runs with no database and no env files, so anything
+  importing a service's `config` at module scope belongs in `.int`. That is precisely the trap
+  that failed CI at the end of 7b; it is written down here so 7c does not repeat it.
+
+## G. Definition of Done
+
+- One Jaeger trace spans gateway → order → inventory → payment → notification for a real
+  checkout driven through the gateway, with the relay gap visible between hops.
+- A `traceId` copied from a log line finds that trace in Jaeger.
+- `traceparent` is absent-tolerant: an envelope minted before this deploy still processes.
+- No business-logic change; every pre-existing test passes unmodified.
+- Nothing in this slice can throw into a production path.
+- `docker compose --profile app up -d` brings Jaeger up with the UI reachable.
+
+### Known limitation carried in
+
+`hello`'s container CrashLoops on a pre-existing corepack/network issue (`services/hello/
+Dockerfile` untouched by 7b, its Prometheus target was already down). Its traces cannot be
+verified in-container this slice either. `hello` is a canary, not on the checkout path, so
+this does not affect the Done-when — but it is now the second slice it has degraded, and it
+should be fixed before 7d.

--- a/packages/contracts/src/__tests__/envelope.unit.test.ts
+++ b/packages/contracts/src/__tests__/envelope.unit.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { EventEnvelopeSchema, makeEnvelope } from "../envelope";
+
+const W3C = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+describe("envelope traceparent", () => {
+  it("carries traceparent through makeEnvelope", () => {
+    const env = makeEnvelope({
+      type: "order.placed",
+      version: 1,
+      traceId: "t",
+      producer: "test",
+      payload: {},
+      traceparent: W3C,
+    });
+    expect(env.traceparent).toBe(W3C);
+  });
+
+  // Deploy safety: an event minted before this deploy has no traceparent at all.
+  // If this ever becomes required, every in-flight event dead-letters.
+  it("parses an envelope with NO traceparent", () => {
+    const parsed = EventEnvelopeSchema.parse({
+      eventId: "3f1a7c62-9b0e-4f5d-8a21-2c7e6d4b1f90",
+      type: "order.placed",
+      version: 1,
+      occurredAt: new Date().toISOString(),
+      traceId: "t",
+      producer: "test",
+      payload: {},
+    });
+    expect(parsed.traceparent).toBeUndefined();
+  });
+
+  it("omits traceparent when the caller supplies none", () => {
+    const env = makeEnvelope({
+      type: "order.placed",
+      version: 1,
+      traceId: "t",
+      producer: "test",
+      payload: {},
+    });
+    expect(env.traceparent).toBeUndefined();
+  });
+});

--- a/packages/contracts/src/__tests__/envelope.unit.test.ts
+++ b/packages/contracts/src/__tests__/envelope.unit.test.ts
@@ -41,4 +41,23 @@ describe("envelope traceparent", () => {
     });
     expect(env.traceparent).toBeUndefined();
   });
+
+  // Discriminates "no key at all" from "key present with value undefined".
+  // `env.traceparent === undefined` is true either way (a missing property
+  // and a present-but-undefined property both read back as undefined), so
+  // only a key-presence check catches a regression to plain assignment
+  // (`traceparent: input.traceparent`), which is observable once this
+  // envelope is JSON-serialized through the outbox row / broker message.
+  it("has NO traceparent key at all when the caller supplies none", () => {
+    const env = makeEnvelope({
+      type: "order.placed",
+      version: 1,
+      traceId: "t",
+      producer: "test",
+      payload: {},
+    });
+    expect("traceparent" in env).toBe(false);
+    expect(Object.keys(env)).not.toContain("traceparent");
+    expect(JSON.stringify(env)).not.toContain("traceparent");
+  });
 });

--- a/packages/contracts/src/envelope.ts
+++ b/packages/contracts/src/envelope.ts
@@ -8,6 +8,9 @@ export const EventEnvelopeSchema = z.object({
   occurredAt: z.string().datetime(),
   traceId: z.string().min(1),
   producer: z.string().min(1),
+  // Optional by design: an event minted before Phase 7c carries none, and a required
+  // field would retry-then-dead-letter every event in flight during the deploy.
+  traceparent: z.string().optional(),
   payload: z.unknown(),
 });
 
@@ -21,6 +24,7 @@ export function makeEnvelope(input: {
   payload: unknown;
   eventId?: string;
   occurredAt?: string;
+  traceparent?: string;
 }): EventEnvelope {
   return {
     eventId: input.eventId ?? uuidv4(),
@@ -29,6 +33,7 @@ export function makeEnvelope(input: {
     occurredAt: input.occurredAt ?? new Date().toISOString(),
     traceId: input.traceId,
     producer: input.producer,
+    ...(input.traceparent ? { traceparent: input.traceparent } : {}),
     payload: input.payload,
   };
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,6 +10,15 @@
   },
   "dependencies": {
     "@ecom/contracts": "workspace:*",
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.221.0",
+    "@opentelemetry/instrumentation-express": "^0.69.0",
+    "@opentelemetry/instrumentation-http": "^0.221.0",
+    "@opentelemetry/instrumentation-redis": "^0.69.0",
+    "@opentelemetry/resources": "^2.10.0",
+    "@opentelemetry/sdk-node": "^0.221.0",
+    "@opentelemetry/semantic-conventions": "^1.43.0",
+    "@prisma/instrumentation": "^6.19.3",
     "amqplib": "^0.10.4",
     "express": "^4.21.0",
     "kafkajs": "^2.2.4",
@@ -20,6 +29,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
+    "@opentelemetry/sdk-trace-node": "^2.10.0",
     "@types/amqplib": "^0.10.5",
     "@types/express": "^4.17.21",
     "@types/supertest": "^6.0.2",

--- a/packages/shared/src/__tests__/outbox.unit.test.ts
+++ b/packages/shared/src/__tests__/outbox.unit.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { drainOutbox, type OutboxRow, type CommandChannel } from "../outbox";
-import { EventEnvelopeSchema } from "@ecom/contracts";
+import {
+  drainOutbox,
+  type OutboxRow,
+  type OutboxPort,
+  type CommandChannel,
+} from "../outbox";
+import { EventEnvelopeSchema, type EventEnvelope } from "@ecom/contracts";
 
 function fakeRow(over: Partial<OutboxRow> = {}): OutboxRow {
   return {
@@ -128,5 +133,81 @@ describe("drainOutbox — command channel routing", () => {
     );
     // the kafka row still committed; the failed rabbit row stays unsent
     expect(marked).toEqual(["cccccccc-cccc-4ccc-8ccc-cccccccccccc"]);
+  });
+});
+
+describe("drainOutbox — traceparent pass-through", () => {
+  it("carries the row's traceparent into the relayed envelope", async () => {
+    const TP = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+    const published: EventEnvelope[] = [];
+    const port: OutboxPort = {
+      async fetchUnsent() {
+        return [
+          {
+            id: "11111111-1111-4111-8111-111111111111",
+            aggregateType: "order",
+            aggregateId: "o1",
+            type: "order.placed",
+            version: 1,
+            traceId: "t",
+            traceparent: TP,
+            producer: "order",
+            payload: {},
+            occurredAt: new Date(),
+            sentAt: null,
+          },
+        ];
+      },
+      async markSent() {},
+    };
+    await drainOutbox(
+      port,
+      {
+        async publish(_t, e) {
+          published.push(e);
+        },
+      },
+      () => "order.events"
+    );
+    expect(published[0].traceparent).toBe(TP);
+  });
+
+  // Prisma returns `null` (not `undefined`) for a nullable column with no value —
+  // that's the real shape of a pre-7c row, so the fake row sets it explicitly
+  // rather than omitting the key. This is what makes the test discriminate against
+  // an implementation that passes the literal `null` through to the envelope
+  // instead of omitting the `traceparent` key: `toBeUndefined()` fails on `null`.
+  it("relays a row with no traceparent (pre-7c rows) without throwing", async () => {
+    const published: EventEnvelope[] = [];
+    const port: OutboxPort = {
+      async fetchUnsent() {
+        return [
+          {
+            id: "22222222-2222-4222-8222-222222222222",
+            aggregateType: "order",
+            aggregateId: "o2",
+            type: "order.placed",
+            version: 1,
+            traceId: "t",
+            traceparent: null,
+            producer: "order",
+            payload: {},
+            occurredAt: new Date(),
+            sentAt: null,
+          },
+        ];
+      },
+      async markSent() {},
+    };
+    await drainOutbox(
+      port,
+      {
+        async publish(_t, e) {
+          published.push(e);
+        },
+      },
+      () => "order.events"
+    );
+    expect(published[0].traceparent).toBeUndefined();
   });
 });

--- a/packages/shared/src/__tests__/trace.test.ts
+++ b/packages/shared/src/__tests__/trace.test.ts
@@ -105,6 +105,15 @@ describe("traceId derives from the active span", () => {
     expect((req as { traceId: string }).traceId).toMatch(/^[0-9a-f-]{36}$/);
   });
 
+  it("prefers the active span's trace id over a simultaneously-present x-trace-id header", () => {
+    const HEADER_TRACE_ID = "legacy-header-should-lose";
+    const req = { header: () => HEADER_TRACE_ID, method: "GET", path: "/x" } as never;
+    const res = { setHeader: () => {} } as never;
+    withSpan(() => traceMiddleware()(req, res, () => {}));
+    expect((req as { traceId: string }).traceId).toBe(TRACE_ID);
+    expect((req as { traceId: string }).traceId).not.toBe(HEADER_TRACE_ID);
+  });
+
   it("currentTraceparent serializes the active span context", () => {
     expect(withSpan(() => currentTraceparent())).toBe(`00-${TRACE_ID}-${SPAN_ID}-01`);
   });

--- a/packages/shared/src/__tests__/trace.test.ts
+++ b/packages/shared/src/__tests__/trace.test.ts
@@ -1,7 +1,26 @@
 import { describe, it, expect, vi } from "vitest";
 import express from "express";
 import request from "supertest";
-import { traceMiddleware, TRACE_HEADER } from "../trace";
+import { context, trace, SpanContext, TraceFlags } from "@opentelemetry/api";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { traceMiddleware, TRACE_HEADER, currentTraceparent } from "../trace";
+
+// @opentelemetry/api's default ContextManager (used whenever nothing has called
+// context.setGlobalContextManager) is a no-op: `context.with(ctx, fn)` just calls
+// `fn()` without ever making `ctx` the active context, so `context.active()` inside
+// `fn` would keep returning the empty ROOT_CONTEXT no matter what was passed to
+// `.with()`. A real ContextManager has to be registered for the "active span" tests
+// below to mean anything. Production processes get one for free from tracing.ts's
+// NodeSDK.start() (Task 2's preload); this test file has none of that, so it
+// registers its own tracer provider — test-only setup. `trace.ts` itself must stay
+// a side-effect-free library import (see Task 2's index.ts boundary note), so this
+// does NOT belong there. @opentelemetry/sdk-trace-node is already a devDependency
+// (added in Task 2 for the later relay/kafka/rabbit span tests), so nothing new
+// needs installing. Registering twice in the same process is already relied on
+// elsewhere in this suite (tracing.unit.test.ts's idempotency test re-runs
+// sdk.start() after a module reset) and is harmless: @opentelemetry/api logs and
+// ignores a duplicate registration rather than throwing.
+new NodeTracerProvider().register();
 
 // Winston's Console transport writes via `console._stdout.write(...)`, and
 // under Vitest `console._stdout` is Vitest's own capture stream, not
@@ -54,5 +73,43 @@ describe("traceMiddleware", () => {
     expect(serialized).not.toContain("user@example.com");
     expect(serialized).not.toContain("hunter2");
     expect(serialized).not.toContain("SECRET50");
+  });
+});
+
+const TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736";
+const SPAN_ID = "00f067aa0ba902b7";
+
+function withSpan<T>(fn: () => T): T {
+  const sc: SpanContext = {
+    traceId: TRACE_ID,
+    spanId: SPAN_ID,
+    traceFlags: TraceFlags.SAMPLED,
+    isRemote: false,
+  };
+  const ctx = trace.setSpanContext(context.active(), sc);
+  return context.with(ctx, fn);
+}
+
+describe("traceId derives from the active span", () => {
+  it("uses the active span's trace id, not a fresh uuid", () => {
+    const req = { header: () => undefined, method: "GET", path: "/x" } as never;
+    const res = { setHeader: () => {} } as never;
+    withSpan(() => traceMiddleware()(req, res, () => {}));
+    expect((req as { traceId: string }).traceId).toBe(TRACE_ID);
+  });
+
+  it("falls back to a uuid when there is no active span (every test run)", () => {
+    const req = { header: () => undefined, method: "GET", path: "/x" } as never;
+    const res = { setHeader: () => {} } as never;
+    traceMiddleware()(req, res, () => {});
+    expect((req as { traceId: string }).traceId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it("currentTraceparent serializes the active span context", () => {
+    expect(withSpan(() => currentTraceparent())).toBe(`00-${TRACE_ID}-${SPAN_ID}-01`);
+  });
+
+  it("currentTraceparent is undefined with no active span", () => {
+    expect(currentTraceparent()).toBeUndefined();
   });
 });

--- a/packages/shared/src/__tests__/tracing-fixture.ts
+++ b/packages/shared/src/__tests__/tracing-fixture.ts
@@ -1,0 +1,17 @@
+// Fixture for tracing.int.test.ts. Deliberately tiny and self-contained: this is
+// the "application code" a real service would run after the tracing preload has
+// evaluated. It starts a span and reports the resulting trace id on stdout, then
+// exits immediately — before the SDK's batch export interval could ever fire, so
+// this needs no live OTLP collector even though the test also sets
+// OTEL_TRACES_EXPORTER=none belt-and-braces.
+//
+// Not run directly by vitest — spawned as a child process by tracing.int.test.ts
+// with NODE_OPTIONS pointing at ../tracing.ts, the same way a real service starts.
+import { trace } from "@opentelemetry/api";
+
+const span = trace.getTracer("tracing-fixture").startSpan("fixture-span");
+const { traceId } = span.spanContext();
+span.end();
+
+process.stdout.write(JSON.stringify({ traceId }) + "\n");
+process.exit(0);

--- a/packages/shared/src/__tests__/tracing-rabbit.unit.test.ts
+++ b/packages/shared/src/__tests__/tracing-rabbit.unit.test.ts
@@ -1,11 +1,20 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
   NodeTracerProvider,
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-node";
+import { trace } from "@opentelemetry/api";
+import amqp from "amqplib";
 import { makeEnvelope } from "@ecom/contracts";
-import { consumerContextFor } from "../rabbitmq";
+import { consumerContextFor, createRabbit } from "../rabbitmq";
+
+// Mocked so createRabbit() can be exercised without a live broker. Hoisted by
+// Vitest above the imports below, so `createRabbit` (imported after this) always
+// sees the mocked module.
+vi.mock("amqplib", () => ({
+  default: { connect: vi.fn() },
+}));
 
 const exporter = new InMemorySpanExporter();
 new NodeTracerProvider({
@@ -52,5 +61,103 @@ describe("rabbit consumer context", () => {
       payload: {},
     });
     expect(() => consumerContextFor(env)).not.toThrow();
+  });
+});
+
+// --- Finding 1 regression: the handler must run with the CONSUMER span active ---
+//
+// Exercises createRabbit()'s consumeCommands() through a minimal fake amqplib
+// channel/connection, so the CONSUMER span's parenting can be asserted without a
+// live broker. context.with(consumerContextFor(env), ...) only rebuilds the
+// extracted upstream context; it never installs the freshly-created `span` as
+// active before invoking the handler. A span started INSIDE the handler is the
+// only way to observe which context is actually active there — asserting on
+// `span` itself (as the tests above do) cannot catch this, because `span` is
+// correctly parented to the extracted context regardless of this bug.
+
+// The parent-span-id accessor moved between SDK majors (`parentSpanId` in v1,
+// `parentSpanContext.spanId` in v2). Read whichever this version exposes rather
+// than pinning one and having the test fail for a reason that is not the behaviour.
+function parentSpanIdOf(span: unknown): string | undefined {
+  return (
+    (span as { parentSpanContext?: { spanId: string } }).parentSpanContext?.spanId ??
+    (span as { parentSpanId?: string }).parentSpanId
+  );
+}
+
+type ConsumeCallback = (msg: { content: Buffer } | null) => unknown;
+
+function fakeChannel() {
+  let onMessage: ConsumeCallback | null = null;
+  const acked: unknown[] = [];
+  const nacked: unknown[] = [];
+  return {
+    prefetch: async () => {},
+    consume: async (_queue: string, cb: ConsumeCallback) => {
+      onMessage = cb;
+      return { consumerTag: "fake-consumer" };
+    },
+    ack: (msg: unknown) => acked.push(msg),
+    nack: (msg: unknown) => nacked.push(msg),
+    acked,
+    nacked,
+    // Test-only helper: invokes the callback amqplib would call on delivery, and
+    // returns its promise so the test can await handler completion.
+    deliver: (raw: string) => onMessage!({ content: Buffer.from(raw) }),
+  };
+}
+
+function fakeConnection(channel: ReturnType<typeof fakeChannel>) {
+  return {
+    createConfirmChannel: async () => channel,
+    on: () => {},
+    close: async () => {},
+  };
+}
+
+describe("rabbit consumer span — Finding 1 (handler must see `span`, not the extracted parent, as active)", () => {
+  it("a span started inside the handler parents to the CONSUMER '... process' span, not to the extracted upstream parent", async () => {
+    const channel = fakeChannel();
+    vi.mocked(amqp.connect).mockResolvedValue(
+      fakeConnection(channel) as unknown as Awaited<ReturnType<typeof amqp.connect>>
+    );
+
+    const rabbit = await createRabbit();
+    let innerSpanId: string | undefined;
+    await rabbit.consumeCommands("payment.charge", async () => {
+      // Simulates a Prisma/outbox span created by application code inside the handler.
+      const inner = trace.getTracer("test-inner").startSpan("inner-work");
+      innerSpanId = inner.spanContext().spanId;
+      inner.end();
+    });
+
+    const env = makeEnvelope({
+      type: "payment.charge",
+      version: 1,
+      traceId: "t",
+      producer: "order",
+      payload: {},
+      traceparent: TP,
+    });
+    await channel.deliver(JSON.stringify(env));
+
+    const processSpan = exporter
+      .getFinishedSpans()
+      .find((s) => s.name === "payment.charge process");
+    const innerSpan = exporter
+      .getFinishedSpans()
+      .find((s) => s.spanContext().spanId === innerSpanId);
+    expect(processSpan).toBeDefined();
+    // Pin the exact name shape (Finding 2) — the acceptance evidence quotes this
+    // literally, making it a de-facto contract for downstream consumers.
+    expect(processSpan!.name).toBe("payment.charge process");
+    expect(innerSpan).toBeDefined();
+    expect(parentSpanIdOf(innerSpan)).toBe(processSpan!.spanContext().spanId);
+    // TP's span id — if this matched instead, the handler ran with the extracted
+    // upstream parent active rather than the consumer `span`.
+    expect(parentSpanIdOf(innerSpan)).not.toBe("00f067aa0ba902b7");
+    // The bug fix must not change delivery outcome: the message still acks normally.
+    expect(channel.acked).toHaveLength(1);
+    expect(channel.nacked).toHaveLength(0);
   });
 });

--- a/packages/shared/src/__tests__/tracing-rabbit.unit.test.ts
+++ b/packages/shared/src/__tests__/tracing-rabbit.unit.test.ts
@@ -36,7 +36,6 @@ describe("rabbit consumer context", () => {
       traceparent: TP,
     });
     const ctx = consumerContextFor(env);
-    const { trace, context } = require("@opentelemetry/api");
     expect(trace.getSpanContext(ctx)!.traceId).toBe("4bf92f3577b34da6a3ce929d0e0e4736");
   });
 

--- a/packages/shared/src/__tests__/tracing-rabbit.unit.test.ts
+++ b/packages/shared/src/__tests__/tracing-rabbit.unit.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  NodeTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-node";
+import { makeEnvelope } from "@ecom/contracts";
+import { consumerContextFor } from "../rabbitmq";
+
+const exporter = new InMemorySpanExporter();
+new NodeTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(exporter)],
+}).register();
+
+const TP = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+beforeEach(() => exporter.reset());
+
+describe("rabbit consumer context", () => {
+  it("extracts the envelope's traceparent as the parent", () => {
+    const env = makeEnvelope({
+      type: "payment.charge",
+      version: 1,
+      traceId: "t",
+      producer: "order",
+      payload: {},
+      traceparent: TP,
+    });
+    const ctx = consumerContextFor(env);
+    const { trace, context } = require("@opentelemetry/api");
+    expect(trace.getSpanContext(ctx)!.traceId).toBe("4bf92f3577b34da6a3ce929d0e0e4736");
+  });
+
+  it("returns the active context — not a throw — for a malformed traceparent", () => {
+    const env = makeEnvelope({
+      type: "payment.charge",
+      version: 1,
+      traceId: "t",
+      producer: "order",
+      payload: {},
+      traceparent: "garbage",
+    });
+    expect(() => consumerContextFor(env)).not.toThrow();
+  });
+
+  it("returns the active context when there is no traceparent at all", () => {
+    const env = makeEnvelope({
+      type: "payment.charge",
+      version: 1,
+      traceId: "t",
+      producer: "order",
+      payload: {},
+    });
+    expect(() => consumerContextFor(env)).not.toThrow();
+  });
+});

--- a/packages/shared/src/__tests__/tracing-seams.unit.test.ts
+++ b/packages/shared/src/__tests__/tracing-seams.unit.test.ts
@@ -68,6 +68,9 @@ describe("relay producer span", () => {
 
     const span = exporter.getFinishedSpans().find((s) => s.name.includes("order.events"));
     expect(span).toBeDefined();
+    // Pin the exact name shape (Finding 2) — the acceptance evidence quotes this
+    // literally, making it a de-facto contract for downstream consumers.
+    expect(span!.name).toBe("order.events publish");
     // Parented to the stored business span…
     expect(span!.spanContext().traceId).toBe("4bf92f3577b34da6a3ce929d0e0e4736");
     expect(parentSpanIdOf(span)).toBe("00f067aa0ba902b7");
@@ -96,6 +99,7 @@ describe("relay producer span", () => {
     // span actually exists, has a well-formed trace id, and has no parent.
     const span = exporter.getFinishedSpans().find((s) => s.name.includes("order.events"));
     expect(span).toBeDefined();
+    expect(span!.name).toBe("order.events publish"); // Finding 2: pin the exact shape
     expect(span!.spanContext().traceId).toMatch(/^[0-9a-f]{32}$/);
     expect(parentSpanIdOf(span)).toBeUndefined();
   });
@@ -186,6 +190,9 @@ describe("relay command-lane producer span", () => {
       .getFinishedSpans()
       .find((s) => s.name.includes("payment.charge"));
     expect(span).toBeDefined();
+    // Pin the exact name shape (Finding 2) — the acceptance evidence quotes this
+    // literally, making it a de-facto contract for downstream consumers.
+    expect(span!.name).toBe("payment.charge send");
     expect(span!.spanContext().traceId).toBe("4bf92f3577b34da6a3ce929d0e0e4736");
     expect(parentSpanIdOf(span)).toBe("00f067aa0ba902b7");
     expect(commanded[0].traceparent).not.toBe(STORED);
@@ -267,6 +274,9 @@ describe("kafka consumer span", () => {
       .getFinishedSpans()
       .find((s) => s.name === "order.events process");
     expect(span).toBeDefined();
+    // Pin the exact name shape (Finding 2) — the acceptance evidence quotes this
+    // literally, making it a de-facto contract for downstream consumers.
+    expect(span!.name).toBe("order.events process");
     expect(span!.spanContext().traceId).toBe("4bf92f3577b34da6a3ce929d0e0e4736");
     expect(parentSpanIdOf(span)).toBe("00f067aa0ba902b7");
   });
@@ -337,5 +347,53 @@ describe("kafka consumer span — Global Constraint 1 (span creation must not af
     // failure changed nothing about delivery (Global Constraint 1 + 2).
     expect(handled).toBe(true);
     expect(parked).toHaveLength(0);
+  });
+});
+
+// --- Finding 1 regression: the handler must run with the CONSUMER span active ---
+//
+// context.with(parent, ...) only rebuilds the extracted upstream context; it never
+// installs the freshly-created `span` as active before invoking the handler. A span
+// started INSIDE the handler is the only way to observe which context is actually
+// active there — asserting on `span` itself (as every test above does) cannot catch
+// this, because `span` is correctly parented to `parent` regardless of this bug.
+describe("kafka consumer span — Finding 1 (handler must see `span`, not `parent`, as active)", () => {
+  it("a span started inside the handler parents to the CONSUMER '... process' span, not to the extracted upstream parent", async () => {
+    const { kafka, deliver } = fakeKafka();
+    const consumer = createConsumer(kafka, "g-active");
+    await consumer.connect();
+
+    let innerSpanId: string | undefined;
+    await consumer.run(["order.events"], async () => {
+      // Simulates a Prisma/outbox span created by application code inside the handler.
+      const inner = trace.getTracer("test-inner").startSpan("inner-work");
+      innerSpanId = inner.spanContext().spanId;
+      inner.end();
+    });
+
+    const raw = JSON.stringify(
+      makeEnvelope({
+        type: "order.placed",
+        version: 1,
+        traceId: "t",
+        producer: "order",
+        payload: {},
+        traceparent: STORED,
+      })
+    );
+    await deliver(raw);
+
+    const processSpan = exporter
+      .getFinishedSpans()
+      .find((s) => s.name === "order.events process");
+    const innerSpan = exporter
+      .getFinishedSpans()
+      .find((s) => s.spanContext().spanId === innerSpanId);
+    expect(processSpan).toBeDefined();
+    expect(innerSpan).toBeDefined();
+    expect(parentSpanIdOf(innerSpan)).toBe(processSpan!.spanContext().spanId);
+    // STORED's span id — if this matched instead, the handler ran with the
+    // extracted upstream `parent` active rather than the consumer `span`.
+    expect(parentSpanIdOf(innerSpan)).not.toBe("00f067aa0ba902b7");
   });
 });

--- a/packages/shared/src/__tests__/tracing-seams.unit.test.ts
+++ b/packages/shared/src/__tests__/tracing-seams.unit.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
   NodeTracerProvider,
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-node";
+import { trace, propagation } from "@opentelemetry/api";
 import type { Kafka } from "kafkajs";
 import { drainOutbox, type OutboxPort, type CommandChannel } from "../outbox";
 import { createConsumer } from "../kafka";
@@ -90,6 +91,61 @@ describe("relay producer span", () => {
       )
     ).resolves.toBeDefined();
     expect(published).toHaveLength(1);
+    // "does not throw" alone doesn't prove a FRESH trace started — a span that
+    // (wrongly) inherited some leftover parent would also not throw. Assert the
+    // span actually exists, has a well-formed trace id, and has no parent.
+    const span = exporter.getFinishedSpans().find((s) => s.name.includes("order.events"));
+    expect(span).toBeDefined();
+    expect(span!.spanContext().traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(parentSpanIdOf(span)).toBeUndefined();
+  });
+});
+
+describe("relay producer span — Global Constraint 1 (creation/injection must not block the send)", () => {
+  it("still publishes when span creation throws", async () => {
+    const published: EventEnvelope[] = [];
+    const getTracerSpy = vi.spyOn(trace, "getTracer").mockReturnValueOnce({
+      startSpan: () => {
+        throw new Error("span creation boom");
+      },
+    } as unknown as ReturnType<typeof trace.getTracer>);
+
+    await drainOutbox(
+      portWith(STORED),
+      {
+        async publish(_t, e) {
+          published.push(e);
+        },
+      },
+      () => "order.events"
+    );
+
+    getTracerSpy.mockRestore();
+    expect(published).toHaveLength(1);
+    // No span could be created, so there was nothing to inject — the row still
+    // gets sent, carrying its original (stored) traceparent rather than being lost.
+    expect(published[0].traceparent).toBe(STORED);
+  });
+
+  it("still publishes, envelope unmodified, when context injection throws", async () => {
+    const published: EventEnvelope[] = [];
+    const injectSpy = vi.spyOn(propagation, "inject").mockImplementationOnce(() => {
+      throw new Error("inject boom");
+    });
+
+    await drainOutbox(
+      portWith(STORED),
+      {
+        async publish(_t, e) {
+          published.push(e);
+        },
+      },
+      () => "order.events"
+    );
+
+    injectSpy.mockRestore();
+    expect(published).toHaveLength(1);
+    expect(published[0].traceparent).toBe(STORED);
   });
 });
 
@@ -150,6 +206,12 @@ type EachMessageHandler = (payload: {
 
 function fakeKafka() {
   let eachMessage: EachMessageHandler = async () => {};
+  // Tracks every producer.send() — the ONLY caller in createConsumer is the DLQ
+  // parker, so a non-empty `parked` after delivery means the message got dead-lettered.
+  const parked: Array<{
+    topic: string;
+    messages: Array<{ key: unknown; value: string }>;
+  }> = [];
   const consumer = {
     events: { END_BATCH_PROCESS: "consumer.end_batch_process" },
     on: () => {},
@@ -163,7 +225,12 @@ function fakeKafka() {
   const producer = {
     connect: async () => {},
     disconnect: async () => {},
-    send: async () => {},
+    send: async (args: {
+      topic: string;
+      messages: Array<{ key: unknown; value: string }>;
+    }) => {
+      parked.push(args);
+    },
   };
   const kafka = {
     consumer: () => consumer,
@@ -171,6 +238,7 @@ function fakeKafka() {
   } as unknown as Kafka;
   return {
     kafka,
+    parked,
     deliver: (raw: string) =>
       eachMessage({ topic: "order.events", message: { value: Buffer.from(raw) } }),
   };
@@ -204,7 +272,7 @@ describe("kafka consumer span", () => {
   });
 
   it("starts a fresh trace when the envelope's traceparent is malformed, and does not throw", async () => {
-    const { kafka, deliver } = fakeKafka();
+    const { kafka, deliver, parked } = fakeKafka();
     const consumer = createConsumer(kafka, "g2");
     await consumer.connect();
     let handled = false;
@@ -224,5 +292,50 @@ describe("kafka consumer span", () => {
     );
     await expect(deliver(raw)).resolves.toBeUndefined();
     expect(handled).toBe(true);
+    expect(parked).toHaveLength(0);
+    // "does not throw" alone doesn't prove a FRESH trace started — assert the
+    // CONSUMER span actually exists, has a well-formed trace id, and has no parent.
+    const span = exporter
+      .getFinishedSpans()
+      .find((s) => s.name === "order.events process");
+    expect(span).toBeDefined();
+    expect(span!.spanContext().traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(parentSpanIdOf(span)).toBeUndefined();
+  });
+});
+
+describe("kafka consumer span — Global Constraint 1 (span creation must not affect delivery)", () => {
+  it("does not park the message when span creation throws — the handler still runs", async () => {
+    const { kafka, deliver, parked } = fakeKafka();
+    const consumer = createConsumer(kafka, "g3");
+    await consumer.connect();
+    let handled = false;
+    await consumer.run(["order.events"], async () => {
+      handled = true;
+    });
+
+    const getTracerSpy = vi.spyOn(trace, "getTracer").mockReturnValueOnce({
+      startSpan: () => {
+        throw new Error("span creation boom");
+      },
+    } as unknown as ReturnType<typeof trace.getTracer>);
+
+    const raw = JSON.stringify(
+      makeEnvelope({
+        type: "order.placed",
+        version: 1,
+        traceId: "t",
+        producer: "order",
+        payload: {},
+        traceparent: STORED,
+      })
+    );
+    await expect(deliver(raw)).resolves.toBeUndefined();
+
+    getTracerSpy.mockRestore();
+    // The handler ran and the message was never dead-lettered — a span-creation
+    // failure changed nothing about delivery (Global Constraint 1 + 2).
+    expect(handled).toBe(true);
+    expect(parked).toHaveLength(0);
   });
 });

--- a/packages/shared/src/__tests__/tracing-seams.unit.test.ts
+++ b/packages/shared/src/__tests__/tracing-seams.unit.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  NodeTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-node";
+import type { Kafka } from "kafkajs";
+import { drainOutbox, type OutboxPort, type CommandChannel } from "../outbox";
+import { createConsumer } from "../kafka";
+import { makeEnvelope, type EventEnvelope } from "@ecom/contracts";
+
+const exporter = new InMemorySpanExporter();
+const provider = new NodeTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(exporter)],
+});
+provider.register();
+
+const STORED = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+beforeEach(() => exporter.reset());
+
+// The parent-span-id accessor moved between SDK majors (`parentSpanId` in v1,
+// `parentSpanContext.spanId` in v2). Read whichever this version exposes rather than
+// pinning one and having the test fail for a reason that is not the behaviour.
+function parentSpanIdOf(span: unknown): string | undefined {
+  return (
+    (span as { parentSpanContext?: { spanId: string } }).parentSpanContext?.spanId ??
+    (span as { parentSpanId?: string }).parentSpanId
+  );
+}
+
+function portWith(traceparent?: string): OutboxPort {
+  return {
+    async fetchUnsent() {
+      return [
+        {
+          id: "33333333-3333-4333-8333-333333333333",
+          aggregateType: "order",
+          aggregateId: "o1",
+          type: "order.placed",
+          version: 1,
+          traceId: "t",
+          traceparent,
+          producer: "order",
+          payload: {},
+          occurredAt: new Date(),
+          sentAt: null,
+        },
+      ];
+    },
+    async markSent() {},
+  };
+}
+
+describe("relay producer span", () => {
+  it("parents to the STORED context and republishes its OWN context", async () => {
+    const published: EventEnvelope[] = [];
+    await drainOutbox(
+      portWith(STORED),
+      {
+        async publish(_t, e) {
+          published.push(e);
+        },
+      },
+      () => "order.events"
+    );
+
+    const span = exporter.getFinishedSpans().find((s) => s.name.includes("order.events"));
+    expect(span).toBeDefined();
+    // Parented to the stored business span…
+    expect(span!.spanContext().traceId).toBe("4bf92f3577b34da6a3ce929d0e0e4736");
+    expect(parentSpanIdOf(span)).toBe("00f067aa0ba902b7");
+    // …but the PUBLISHED envelope carries the relay's own span, not the stored one.
+    // This is what lets the consumer parent to the relay and makes the poll gap visible.
+    expect(published[0].traceparent).not.toBe(STORED);
+    expect(published[0].traceparent).toContain(span!.spanContext().spanId);
+  });
+
+  it("starts a fresh trace when the stored traceparent is malformed, and does not throw", async () => {
+    const published: EventEnvelope[] = [];
+    await expect(
+      drainOutbox(
+        portWith("not-a-traceparent"),
+        {
+          async publish(_t, e) {
+            published.push(e);
+          },
+        },
+        () => "order.events"
+      )
+    ).resolves.toBeDefined();
+    expect(published).toHaveLength(1);
+  });
+});
+
+describe("relay command-lane producer span", () => {
+  it("parents the ChargePayment send to the STORED context and republishes its OWN context", async () => {
+    const commanded: EventEnvelope[] = [];
+    const commands: CommandChannel = {
+      sender: {
+        async sendCommand(_q, e) {
+          commanded.push(e);
+        },
+      },
+      queueFor: (r) => (r.type === "payment.charge" ? "payment.charge" : null),
+    };
+    const row = {
+      id: "44444444-4444-4444-8444-444444444444",
+      aggregateType: "order",
+      aggregateId: "o1",
+      type: "payment.charge",
+      version: 1,
+      traceId: "t",
+      traceparent: STORED,
+      producer: "order",
+      payload: {},
+      occurredAt: new Date(),
+      sentAt: null,
+    };
+    const port: OutboxPort = {
+      async fetchUnsent() {
+        return [row];
+      },
+      async markSent() {},
+    };
+
+    await drainOutbox(port, { async publish() {} }, () => "order.events", 100, commands);
+
+    const span = exporter
+      .getFinishedSpans()
+      .find((s) => s.name.includes("payment.charge"));
+    expect(span).toBeDefined();
+    expect(span!.spanContext().traceId).toBe("4bf92f3577b34da6a3ce929d0e0e4736");
+    expect(parentSpanIdOf(span)).toBe("00f067aa0ba902b7");
+    expect(commanded[0].traceparent).not.toBe(STORED);
+    expect(commanded[0].traceparent).toContain(span!.spanContext().spanId);
+  });
+});
+
+// --- Kafka consumer span --------------------------------------------------
+//
+// Exercises createConsumer()'s eachMessage handler through a minimal fake Kafka
+// client (same shape as kafka-hooks.unit.test.ts's fixture), so the CONSUMER span's
+// parenting can be asserted without a live broker.
+
+type EachMessageHandler = (payload: {
+  topic: string;
+  message: { value: Buffer | null };
+}) => Promise<void>;
+
+function fakeKafka() {
+  let eachMessage: EachMessageHandler = async () => {};
+  const consumer = {
+    events: { END_BATCH_PROCESS: "consumer.end_batch_process" },
+    on: () => {},
+    connect: async () => {},
+    disconnect: async () => {},
+    subscribe: async () => {},
+    run: async (opts: { eachMessage: EachMessageHandler }) => {
+      eachMessage = opts.eachMessage;
+    },
+  };
+  const producer = {
+    connect: async () => {},
+    disconnect: async () => {},
+    send: async () => {},
+  };
+  const kafka = {
+    consumer: () => consumer,
+    producer: () => producer,
+  } as unknown as Kafka;
+  return {
+    kafka,
+    deliver: (raw: string) =>
+      eachMessage({ topic: "order.events", message: { value: Buffer.from(raw) } }),
+  };
+}
+
+describe("kafka consumer span", () => {
+  it("parents the CONSUMER span to the envelope's traceparent (the relay's span)", async () => {
+    const { kafka, deliver } = fakeKafka();
+    const consumer = createConsumer(kafka, "g1");
+    await consumer.connect();
+    await consumer.run(["order.events"], async () => {});
+
+    const raw = JSON.stringify(
+      makeEnvelope({
+        type: "order.placed",
+        version: 1,
+        traceId: "t",
+        producer: "order",
+        payload: {},
+        traceparent: STORED,
+      })
+    );
+    await deliver(raw);
+
+    const span = exporter
+      .getFinishedSpans()
+      .find((s) => s.name === "order.events process");
+    expect(span).toBeDefined();
+    expect(span!.spanContext().traceId).toBe("4bf92f3577b34da6a3ce929d0e0e4736");
+    expect(parentSpanIdOf(span)).toBe("00f067aa0ba902b7");
+  });
+
+  it("starts a fresh trace when the envelope's traceparent is malformed, and does not throw", async () => {
+    const { kafka, deliver } = fakeKafka();
+    const consumer = createConsumer(kafka, "g2");
+    await consumer.connect();
+    let handled = false;
+    await consumer.run(["order.events"], async () => {
+      handled = true;
+    });
+
+    const raw = JSON.stringify(
+      makeEnvelope({
+        type: "order.placed",
+        version: 1,
+        traceId: "t",
+        producer: "order",
+        payload: {},
+        traceparent: "not-a-traceparent",
+      })
+    );
+    await expect(deliver(raw)).resolves.toBeUndefined();
+    expect(handled).toBe(true);
+  });
+});

--- a/packages/shared/src/__tests__/tracing.int.test.ts
+++ b/packages/shared/src/__tests__/tracing.int.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import path from "node:path";
+
+// Integration (not unit): spawns a real child process. Slow relative to the rest
+// of the suite (a cold tsx transform is not fast), and the CI "quality" lane
+// excludes *.int.test.ts — this runs in the integration lane instead.
+//
+// Why this test exists, and why the unit test isn't enough: the unit test's
+// `vi.resetModules()` only clears vitest's own module cache. It never touches
+// `globalThis`, never touches `process.env`, and never crosses a process
+// boundary — so it cannot detect a guard that is wrong on exactly those axes.
+// Fix round 1 of this task shipped (then reverted) a `process.env`-based guard
+// that silently disabled the SDK in the one process that actually runs
+// application code, while still logging "tracing_started" exactly once and
+// passing every existing test. This test is the one built specifically to catch
+// that class of bug: it spawns a process the way a real service starts (preload
+// via NODE_OPTIONS, not an in-process import) and inspects what the *spawned*
+// process's SDK actually did, not what the log said.
+
+const execFileAsync = promisify(execFile);
+
+// __dirname, not import.meta.url: this repo's tsconfig targets "module":
+// "commonjs" (see tsconfig.base.json), which rejects import.meta outright
+// (TS1343). __dirname is the repo's own established pattern for this — see
+// e.g. every service's src/db.ts (`path.resolve(__dirname, "../.env")`).
+const repoRoot = path.resolve(__dirname, "../../../..");
+const tracingPreloadPath = path.resolve(__dirname, "../tracing.ts");
+const fixturePath = path.resolve(__dirname, "tracing-fixture.ts");
+// The local tsx CLI binary, not plain `node` and not `npx tsx`: every service in
+// this repo starts via `"start": "tsx src/main.ts"`, which resolves to exactly
+// this binary. This choice is load-bearing, not stylistic — `tsx <file>` respawns
+// itself into a child process (see task-2-report.md fix round 1), and it is
+// specifically that parent-sets-env / child-inherits-env handoff that the
+// previously-shipped process.env guard bug depended on. A plain `node <fixture>`
+// invocation is a single process with no such handoff, and was confirmed NOT to
+// discriminate against that bug during this test's own development (see fix
+// round 2 in task-2-report.md) — it must go through the real respawn to be able
+// to catch a regression of it.
+const tsxBinPath = path.resolve(repoRoot, "node_modules/.bin/tsx");
+
+// The all-zero trace id is not a real identifier — it's the literal sentinel
+// @opentelemetry/api's no-op tracer returns when no SDK/TracerProvider has been
+// registered in the current process. Seeing it here means the tracing preload
+// did not actually start an SDK in the process that ran the fixture.
+const NO_SDK_REGISTERED_TRACE_ID = "00000000000000000000000000000000";
+
+describe("tracing bootstrap (integration — spawns a real child process)", () => {
+  it("registers a working SDK in the process that runs application code", async () => {
+    const { stdout } = await execFileAsync(tsxBinPath, [fixturePath], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        // Same preload mechanism every service uses in production:
+        // NODE_OPTIONS=--import tsx --import file://.../tracing.ts, and the same
+        // `tsx <file>` entry point every service's "start" script uses — which is
+        // what actually makes the parent-process/respawned-child shape (and the
+        // guard bug that shape exposed) real here rather than assumed away.
+        NODE_OPTIONS: `--import tsx --import file://${tracingPreloadPath}`,
+        OTEL_SERVICE_NAME: "tracing-int-test",
+        // No collector needed: the fixture reads the trace id off the span
+        // context synchronously and exits before any batch export could fire.
+        // Set anyway, belt-and-braces, so this test can never depend on one.
+        OTEL_TRACES_EXPORTER: "none",
+      },
+      timeout: 30_000,
+    });
+
+    // Preload logging (tracing.ts's own "tracing_started" line) and the
+    // fixture's own output both land on stdout; the fixture's JSON is always
+    // the last line, since it's written immediately before the fixture exits.
+    const lastLine = stdout.trim().split("\n").at(-1) ?? "";
+    let traceId: string;
+    try {
+      ({ traceId } = JSON.parse(lastLine) as { traceId: string });
+    } catch {
+      throw new Error(
+        `Fixture did not print the expected JSON on its last stdout line. ` +
+          `Full stdout:\n${stdout}`
+      );
+    }
+
+    expect(
+      traceId,
+      `Got the all-zero sentinel trace id ("${NO_SDK_REGISTERED_TRACE_ID}"), which ` +
+        `means no OTel SDK was registered in the process that ran the fixture — the ` +
+        `tracing preload did not actually start tracing there, even though it may ` +
+        `still have logged "tracing_started" (that log line alone does not prove the ` +
+        `SDK is active in the process that runs application code; see tracing.ts and ` +
+        `task-2-report.md fix round 1 for the guard bug this test exists to catch).`
+    ).not.toBe(NO_SDK_REGISTERED_TRACE_ID);
+  }, 30_000);
+});

--- a/packages/shared/src/__tests__/tracing.unit.test.ts
+++ b/packages/shared/src/__tests__/tracing.unit.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+
+describe("tracing bootstrap", () => {
+  it("is idempotent — a second evaluation does not start a second SDK", async () => {
+    const first = await import("../tracing");
+    expect(first.tracingStarted()).toBe(true);
+
+    // Re-evaluate the module with a cleared registry — this is what the tsx loader
+    // does, and it is the case a module-local flag would fail to guard. Use
+    // vi.resetModules(), NOT an `import("../tracing?query")` cache-buster: vitest
+    // resolves that through its own transform pipeline and it does not reliably
+    // produce a second evaluation.
+    vi.resetModules();
+    const second = await import("../tracing");
+    expect(second.tracingStarted()).toBe(true);
+    expect(globalThis.__ecomTracingStarted__).toBe(true);
+  });
+
+  it("enables exactly the intended instrumentations and no messaging ones", async () => {
+    const { ENABLED_INSTRUMENTATIONS } = await import("../tracing");
+    expect(ENABLED_INSTRUMENTATIONS).toEqual([
+      "@opentelemetry/instrumentation-http",
+      "@opentelemetry/instrumentation-express",
+      "@opentelemetry/instrumentation-redis",
+      "@prisma/instrumentation",
+    ]);
+    // The load-bearing assertion: these propagate via broker headers while this system
+    // propagates via the envelope. Enabling both yields traces that are correct on sync
+    // hops and quietly wrong on async ones.
+    expect(ENABLED_INSTRUMENTATIONS).not.toContain(
+      "@opentelemetry/instrumentation-kafkajs"
+    );
+    expect(ENABLED_INSTRUMENTATIONS).not.toContain(
+      "@opentelemetry/instrumentation-amqplib"
+    );
+  });
+});

--- a/packages/shared/src/__tests__/tracing.unit.test.ts
+++ b/packages/shared/src/__tests__/tracing.unit.test.ts
@@ -1,6 +1,35 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 
 describe("tracing bootstrap", () => {
+  afterEach(() => {
+    // Leave both the mock registry and the module cache clean: the next test's
+    // plain `import("../tracing")` (no resetModules of its own) must see a truly
+    // fresh, unmocked evaluation, not the cached instance built under the mock.
+    vi.doUnmock("node:worker_threads");
+    vi.resetModules();
+  });
+
+  it("does not start the SDK on a non-main thread (e.g. tsx's own transform worker)", async () => {
+    // Fix round 1: tsx's --import hook itself uses a worker_threads.Worker
+    // internally (its esbuild transform service), and because NODE_OPTIONS still
+    // points at this file, that worker evaluates it too — on a thread that will
+    // never carry a single span. A probe against the real preload mechanism
+    // (see task-2-report.md) found this module logging tracing_started from
+    // inside that worker. Starting a real SDK/exporter there is unreachable
+    // dead weight for the process's lifetime, so start() must bail out before
+    // touching any guard state when it isn't the main thread.
+    vi.doMock("node:worker_threads", () => ({ isMainThread: false, threadId: 7 }));
+    // Start from a clean slate: a prior test in this file may already have set
+    // this via a real (main-thread) import, and that must not mask a broken skip.
+    globalThis.__ecomTracingStarted__ = undefined;
+
+    vi.resetModules();
+    const mod = await import("../tracing");
+
+    expect(mod.tracingStarted()).toBe(false);
+    expect(globalThis.__ecomTracingStarted__).not.toBe(true);
+  });
+
   it("is idempotent — a second evaluation does not start a second SDK", async () => {
     const first = await import("../tracing");
     expect(first.tracingStarted()).toBe(true);

--- a/packages/shared/src/kafka.ts
+++ b/packages/shared/src/kafka.ts
@@ -1,10 +1,16 @@
 import { Kafka, logLevel, type Producer, type Consumer } from "kafkajs";
+import { trace, context, propagation, SpanKind } from "@opentelemetry/api";
 import { EventEnvelopeSchema, type EventEnvelope } from "@ecom/contracts";
 import { withRetry } from "./retry";
 import { createLogger } from "./logger";
 import type { KafkaMetricsHooks } from "./metrics";
 
 const log = createLogger("kafka");
+// Resolved lazily (NOT cached at module scope) — see outbox.ts's `tracer()` for why:
+// a ProxyTracer obtained before a TracerProvider registers stays permanently unbound.
+function tracer() {
+  return trace.getTracer("@ecom/shared/kafka");
+}
 
 export function createKafka(clientId: string): Kafka {
   return new Kafka({
@@ -74,7 +80,34 @@ export function createConsumer(kafka: Kafka, groupId: string, hooks?: KafkaMetri
           try {
             const env = EventEnvelopeSchema.parse(JSON.parse(raw));
             const started = process.hrtime.bigint();
-            await withRetry(() => handler(env), { retries: maxRetries, baseMs: 200 });
+            // Rebuild a context from the envelope's traceparent (the relay's own span,
+            // stamped in Task 6's outbox.ts — not the original business span). Never
+            // throws: a malformed value from an older or untrusted producer yields the
+            // active context, which starts a fresh trace rather than rejecting the message.
+            const parent = (() => {
+              try {
+                return env.traceparent
+                  ? propagation.extract(context.active(), {
+                      traceparent: env.traceparent,
+                    })
+                  : context.active();
+              } catch {
+                return context.active();
+              }
+            })();
+            await context.with(parent, async () => {
+              const span = tracer().startSpan(`${topic} process`, {
+                kind: SpanKind.CONSUMER,
+              });
+              // IDs only — never the payload (Global Constraint 9).
+              span.setAttribute("messaging.message.id", env.eventId);
+              span.setAttribute("messaging.destination.name", topic);
+              try {
+                await withRetry(() => handler(env), { retries: maxRetries, baseMs: 200 });
+              } finally {
+                span.end();
+              }
+            });
             // Recording is wrapped SEPARATELY from the handler's try. Unwrapped, a throwing
             // hook would fall into the DLQ catch below and park a message whose handler
             // already succeeded.

--- a/packages/shared/src/kafka.ts
+++ b/packages/shared/src/kafka.ts
@@ -118,7 +118,16 @@ export function createConsumer(kafka: Kafka, groupId: string, hooks?: KafkaMetri
                 span = undefined;
               }
               try {
-                await withRetry(() => handler(env), { retries: maxRetries, baseMs: 200 });
+                const runHandler = () =>
+                  withRetry(() => handler(env), { retries: maxRetries, baseMs: 200 });
+                // The handler must run with `span` — not `parent` — active, so any
+                // spans it creates (Prisma, outbox writes) parent to THIS consumer
+                // span rather than to the upstream relay's producer span. When span
+                // creation above failed, `span` is undefined and the handler runs
+                // directly, unchanged.
+                await (span
+                  ? context.with(trace.setSpan(context.active(), span), runHandler)
+                  : runHandler());
               } finally {
                 try {
                   span?.end();

--- a/packages/shared/src/kafka.ts
+++ b/packages/shared/src/kafka.ts
@@ -1,13 +1,18 @@
 import { Kafka, logLevel, type Producer, type Consumer } from "kafkajs";
-import { trace, context, propagation, SpanKind } from "@opentelemetry/api";
+import { trace, context, propagation, SpanKind, type Span } from "@opentelemetry/api";
 import { EventEnvelopeSchema, type EventEnvelope } from "@ecom/contracts";
 import { withRetry } from "./retry";
 import { createLogger } from "./logger";
 import type { KafkaMetricsHooks } from "./metrics";
 
 const log = createLogger("kafka");
-// Resolved lazily (NOT cached at module scope) — see outbox.ts's `tracer()` for why:
-// a ProxyTracer obtained before a TracerProvider registers stays permanently unbound.
+// Resolved lazily (NOT cached at module scope). See outbox.ts's `tracer()` for the
+// full repro: under Vitest, this file's ESM `import` of @opentelemetry/api and
+// @opentelemetry/sdk-trace-node's internal CJS `require()` of it resolve to two
+// separate TraceAPI singletons (verified by object-identity comparison), so a
+// ProxyTracer obtained here before a test's NodeTracerProvider.register() runs would
+// bind to a side that never receives the delegate. Resolving at span-creation time
+// (well after any registration) avoids that. Production is unaffected.
 function tracer() {
   return trace.getTracer("@ecom/shared/kafka");
 }
@@ -96,16 +101,30 @@ export function createConsumer(kafka: Kafka, groupId: string, hooks?: KafkaMetri
               }
             })();
             await context.with(parent, async () => {
-              const span = tracer().startSpan(`${topic} process`, {
-                kind: SpanKind.CONSUMER,
-              });
-              // IDs only — never the payload (Global Constraint 9).
-              span.setAttribute("messaging.message.id", env.eventId);
-              span.setAttribute("messaging.destination.name", topic);
+              // Global Constraint 1: span creation (and the attribute calls right
+              // after it) is wrapped — a throw here must never skip the handler call
+              // below. Unwrapped, it would propagate out of this context.with(),
+              // land in the outer try's catch, and park a message whose handler was
+              // never even invoked: exactly what Global Constraint 2 forbids.
+              let span: Span | undefined;
+              try {
+                span = tracer().startSpan(`${topic} process`, {
+                  kind: SpanKind.CONSUMER,
+                });
+                // IDs only — never the payload (Global Constraint 9).
+                span.setAttribute("messaging.message.id", env.eventId);
+                span.setAttribute("messaging.destination.name", topic);
+              } catch {
+                span = undefined;
+              }
               try {
                 await withRetry(() => handler(env), { retries: maxRetries, baseMs: 200 });
               } finally {
-                span.end();
+                try {
+                  span?.end();
+                } catch {
+                  /* span teardown must never affect message handling */
+                }
               }
             });
             // Recording is wrapped SEPARATELY from the handler's try. Unwrapped, a throwing

--- a/packages/shared/src/outbox.ts
+++ b/packages/shared/src/outbox.ts
@@ -1,14 +1,22 @@
-import { trace, context, propagation, SpanKind } from "@opentelemetry/api";
+import { trace, context, propagation, SpanKind, type Span } from "@opentelemetry/api";
 import { makeEnvelope, type EventEnvelope } from "@ecom/contracts";
 import { createLogger } from "./logger";
 
 const log = createLogger("outbox");
-// Resolved lazily (NOT cached at module scope) — trace.getTracer() returns a
-// ProxyTracer that permanently binds to whatever provider is registered at the
-// moment it's first asked for a span. Caching it in a module-level const risks
-// binding it to a no-op provider if this module is imported before a
-// TracerProvider registers (exactly what a test file that imports drainOutbox
-// before calling `new NodeTracerProvider(...).register()` would trigger).
+// Resolved lazily (NOT cached at module scope). Verified under Vitest, by direct
+// object-identity comparison: this file's `import { trace } from "@opentelemetry/api"`
+// (ESM) and @opentelemetry/sdk-trace-node's internal `require("@opentelemetry/api")`
+// (CJS — sdk-trace-node is itself CJS) resolve to TWO SEPARATE module instances —
+// two separate TraceAPI singletons, `esmTrace === cjsRequire("@opentelemetry/api").trace`
+// is false — even though only one copy of the package is installed on disk. A
+// ProxyTracer obtained via trace.getTracer() BEFORE `NodeTracerProvider.register()`
+// runs binds permanently to the ESM side's own local ProxyTracerProvider, which never
+// receives a delegate (register() sets the delegate on the CJS side's singleton
+// instead). A getTracer() call made AFTER registration resolves correctly regardless
+// of which side registered, because it reads through the shared globalThis registry.
+// Full repro in task-6-report.md's fix-round section. Production is unaffected —
+// tracing.ts's NODE_OPTIONS preload always registers before this module's own import
+// graph loads, so there is only one registration order there.
 function tracer() {
   return trace.getTracer("@ecom/shared/outbox");
 }
@@ -79,6 +87,12 @@ function contextFromRow(row: OutboxRow) {
 // to the original business operation — and the polling delay shows up as the gap
 // between the business span ending and this one starting. The stored row itself is
 // never mutated: a replayed row still re-parents to the original business operation.
+//
+// Global Constraint 1: span creation and context injection are each wrapped, same as
+// extraction in contextFromRow — a throw from either must never stop `send` (the
+// row's actual publish) from being attempted. Span creation failing falls back to no
+// span at all; injection failing falls back to publishing the envelope unmodified
+// (its original traceparent, if any, rather than the relay's).
 async function publishWithSpan<T>(
   row: OutboxRow,
   spanName: string,
@@ -87,16 +101,31 @@ async function publishWithSpan<T>(
   const envelope = toEnvelope(row);
   const parent = contextFromRow(row);
   return context.with(parent, async () => {
-    const span = tracer().startSpan(spanName, { kind: SpanKind.PRODUCER });
+    let span: Span | undefined;
     try {
-      const carrier: Record<string, string> = {};
-      propagation.inject(trace.setSpan(context.active(), span), carrier);
-      const outgoing = carrier.traceparent
-        ? { ...envelope, traceparent: carrier.traceparent }
-        : envelope;
+      span = tracer().startSpan(spanName, { kind: SpanKind.PRODUCER });
+    } catch {
+      span = undefined;
+    }
+    try {
+      let outgoing = envelope;
+      if (span) {
+        try {
+          const carrier: Record<string, string> = {};
+          propagation.inject(trace.setSpan(context.active(), span), carrier);
+          if (carrier.traceparent)
+            outgoing = { ...envelope, traceparent: carrier.traceparent };
+        } catch {
+          /* injection failed — publish the envelope as built, unmodified */
+        }
+      }
       return await send(outgoing);
     } finally {
-      span.end();
+      try {
+        span?.end();
+      } catch {
+        /* span teardown must never block the relay tick */
+      }
     }
   });
 }

--- a/packages/shared/src/outbox.ts
+++ b/packages/shared/src/outbox.ts
@@ -1,7 +1,17 @@
+import { trace, context, propagation, SpanKind } from "@opentelemetry/api";
 import { makeEnvelope, type EventEnvelope } from "@ecom/contracts";
 import { createLogger } from "./logger";
 
 const log = createLogger("outbox");
+// Resolved lazily (NOT cached at module scope) — trace.getTracer() returns a
+// ProxyTracer that permanently binds to whatever provider is registered at the
+// moment it's first asked for a span. Caching it in a module-level const risks
+// binding it to a no-op provider if this module is imported before a
+// TracerProvider registers (exactly what a test file that imports drainOutbox
+// before calling `new NodeTracerProvider(...).register()` would trigger).
+function tracer() {
+  return trace.getTracer("@ecom/shared/outbox");
+}
 
 export type OutboxRow = {
   id: string;
@@ -51,6 +61,46 @@ function toEnvelope(row: OutboxRow): EventEnvelope {
   });
 }
 
+// Rebuild a context from the stored traceparent. Never throws: a malformed value from an
+// older or untrusted producer yields the active context, which starts a fresh trace.
+function contextFromRow(row: OutboxRow) {
+  try {
+    return row.traceparent
+      ? propagation.extract(context.active(), { traceparent: row.traceparent })
+      : context.active();
+  } catch {
+    return context.active();
+  }
+}
+
+// Wraps a single relayed send (Kafka publish or Rabbit sendCommand) in a PRODUCER span
+// parented to the row's STORED context. The outgoing envelope's traceparent is then
+// overwritten with THIS span's own context, so the consumer parents to the relay — not
+// to the original business operation — and the polling delay shows up as the gap
+// between the business span ending and this one starting. The stored row itself is
+// never mutated: a replayed row still re-parents to the original business operation.
+async function publishWithSpan<T>(
+  row: OutboxRow,
+  spanName: string,
+  send: (envelope: EventEnvelope) => Promise<T>
+): Promise<T> {
+  const envelope = toEnvelope(row);
+  const parent = contextFromRow(row);
+  return context.with(parent, async () => {
+    const span = tracer().startSpan(spanName, { kind: SpanKind.PRODUCER });
+    try {
+      const carrier: Record<string, string> = {};
+      propagation.inject(trace.setSpan(context.active(), span), carrier);
+      const outgoing = carrier.traceparent
+        ? { ...envelope, traceparent: carrier.traceparent }
+        : envelope;
+      return await send(outgoing);
+    } finally {
+      span.end();
+    }
+  });
+}
+
 export async function drainOutbox(
   port: OutboxPort,
   producer: ProducerPort,
@@ -80,10 +130,20 @@ export async function drainOutbox(
   };
   // Lanes are independent: a Rabbit outage must not wedge the Kafka rows.
   const results = await Promise.allSettled([
-    lane(kafkaRows, (r) => producer.publish(topicFor(r.aggregateType), toEnvelope(r))),
+    lane(kafkaRows, (r) => {
+      const topic = topicFor(r.aggregateType);
+      return publishWithSpan(r, `${topic} publish`, (envelope) =>
+        producer.publish(topic, envelope)
+      );
+    }),
     lane(
       rabbitRows.map((r) => r.row),
-      (r) => commands!.sender.sendCommand(queueById.get(r.id)!, toEnvelope(r))
+      (r) => {
+        const queue = queueById.get(r.id)!;
+        return publishWithSpan(r, `${queue} send`, (envelope) =>
+          commands!.sender.sendCommand(queue, envelope)
+        );
+      }
     ),
   ]);
   for (const r of results) {

--- a/packages/shared/src/outbox.ts
+++ b/packages/shared/src/outbox.ts
@@ -10,6 +10,8 @@ export type OutboxRow = {
   type: string;
   version: number;
   traceId: string;
+  // Nullable: rows written before Phase 7c have none, and Prisma returns null not undefined.
+  traceparent?: string | null;
   producer: string;
   payload: unknown;
   occurredAt: Date;
@@ -43,6 +45,7 @@ function toEnvelope(row: OutboxRow): EventEnvelope {
     version: row.version,
     occurredAt: row.occurredAt.toISOString(),
     traceId: row.traceId,
+    ...(row.traceparent ? { traceparent: row.traceparent } : {}),
     producer: row.producer,
     payload: row.payload,
   });

--- a/packages/shared/src/rabbitmq.ts
+++ b/packages/shared/src/rabbitmq.ts
@@ -140,11 +140,19 @@ export async function createRabbit(
           span = undefined;
         }
         try {
-          await withRetry(() => handler(env), {
-            retries: maxRetries,
-            baseMs: 200,
-            label: `consume:${queue}`,
-          });
+          const runHandler = () =>
+            withRetry(() => handler(env), {
+              retries: maxRetries,
+              baseMs: 200,
+              label: `consume:${queue}`,
+            });
+          // The handler must run with `span` — not the extracted `parent` — active,
+          // so any spans it creates parent to THIS consumer span rather than to the
+          // upstream relay's producer span. When span creation above failed, `span`
+          // is undefined and the handler runs directly, unchanged.
+          await (span
+            ? context.with(trace.setSpan(context.active(), span), runHandler)
+            : runHandler());
           ch.ack(msg);
         } catch {
           ch.nack(msg, false, false); // handler exhausted retries -> DLX/DLQ

--- a/packages/shared/src/rabbitmq.ts
+++ b/packages/shared/src/rabbitmq.ts
@@ -1,9 +1,33 @@
 import amqp, { type ConfirmChannel, type ChannelModel, type Channel } from "amqplib";
+import { trace, context, propagation, SpanKind, type Span } from "@opentelemetry/api";
 import { EventEnvelopeSchema, type EventEnvelope } from "@ecom/contracts";
 import { withRetry } from "./retry";
 import { createLogger } from "./logger";
 
 const log = createLogger("rabbit");
+// Resolved lazily (NOT cached at module scope). See outbox.ts's `tracer()` for the
+// full repro: under Vitest, this file's ESM `import` of @opentelemetry/api and
+// @opentelemetry/sdk-trace-node's internal CJS `require()` of it resolve to two
+// separate TraceAPI singletons, so a ProxyTracer obtained here before a test's
+// NodeTracerProvider.register() runs would bind to a side that never receives the
+// delegate. Resolving at span-creation time (well after any registration) avoids
+// that. Production is unaffected.
+function tracer() {
+  return trace.getTracer("@ecom/shared/rabbitmq");
+}
+
+// Exported for the unit test: the extraction is the part that can silently regress.
+// Never throws: a malformed or missing traceparent yields the active context, which
+// starts a fresh trace rather than rejecting the message.
+export function consumerContextFor(env: EventEnvelope) {
+  try {
+    return env.traceparent
+      ? propagation.extract(context.active(), { traceparent: env.traceparent })
+      : context.active();
+  } catch {
+    return context.active();
+  }
+}
 
 // Connection-liveness state machine, split out so the restart decision is unit-testable
 // without a broker. Docker restart policies fire on process EXIT, never on an unhealthy
@@ -100,16 +124,38 @@ export async function createRabbit(
         ch.nack(msg, false, false); // malformed envelope -> DLQ; retrying can't help
         return;
       }
-      try {
-        await withRetry(() => handler(env), {
-          retries: maxRetries,
-          baseMs: 200,
-          label: `consume:${queue}`,
-        });
-        ch.ack(msg);
-      } catch {
-        ch.nack(msg, false, false); // handler exhausted retries -> DLX/DLQ
-      }
+      await context.with(consumerContextFor(env), async () => {
+        // Global Constraint 1: span creation (and the attribute calls right after it)
+        // is wrapped SEPARATELY from the retry/DLQ try below — a throw here must never
+        // skip the handler call. Unwrapped, it would propagate out of this
+        // context.with(), land in the retry/DLQ catch, and nack/DLQ a message whose
+        // handler was never even invoked: exactly what Global Constraint 2 forbids.
+        let span: Span | undefined;
+        try {
+          span = tracer().startSpan(`${queue} process`, { kind: SpanKind.CONSUMER });
+          // IDs only — never the payload (sensitive-logging / tracing hygiene).
+          span.setAttribute("messaging.message.id", env.eventId);
+          span.setAttribute("messaging.destination.name", queue);
+        } catch {
+          span = undefined;
+        }
+        try {
+          await withRetry(() => handler(env), {
+            retries: maxRetries,
+            baseMs: 200,
+            label: `consume:${queue}`,
+          });
+          ch.ack(msg);
+        } catch {
+          ch.nack(msg, false, false); // handler exhausted retries -> DLX/DLQ
+        } finally {
+          try {
+            span?.end();
+          } catch {
+            /* span teardown must never affect message handling */
+          }
+        }
+      });
     });
   }
 

--- a/packages/shared/src/trace.ts
+++ b/packages/shared/src/trace.ts
@@ -15,17 +15,21 @@ declare global {
   }
 }
 
+// The sentinel @opentelemetry/api's no-op tracer returns when no SDK/TracerProvider
+// is registered in the current process — i.e. "no real span," not a real trace id.
+const NO_ACTIVE_SPAN_TRACE_ID = "00000000000000000000000000000000";
+
 // The active span's trace id IS the traceId now, so a log line pastes straight into
 // Jaeger. With no active span — every test run, and any service started without the
 // NODE_OPTIONS preload — fall back to the old uuid so nothing that works today stops.
 function activeTraceId(): string | undefined {
   const sc = trace.getSpanContext(context.active());
-  return sc && sc.traceId !== "00000000000000000000000000000000" ? sc.traceId : undefined;
+  return sc && sc.traceId !== NO_ACTIVE_SPAN_TRACE_ID ? sc.traceId : undefined;
 }
 
 export function currentTraceparent(): string | undefined {
   const sc = trace.getSpanContext(context.active());
-  if (!sc || sc.traceId === "00000000000000000000000000000000") return undefined;
+  if (!sc || sc.traceId === NO_ACTIVE_SPAN_TRACE_ID) return undefined;
   return `00-${sc.traceId}-${sc.spanId}-${sc.traceFlags.toString(16).padStart(2, "0")}`;
 }
 

--- a/packages/shared/src/trace.ts
+++ b/packages/shared/src/trace.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from "express";
 import { v4 as uuidv4 } from "uuid";
+import { trace, context } from "@opentelemetry/api";
 import { createLogger } from "./logger";
 
 export const TRACE_HEADER = "x-trace-id";
@@ -14,10 +15,28 @@ declare global {
   }
 }
 
+// The active span's trace id IS the traceId now, so a log line pastes straight into
+// Jaeger. With no active span — every test run, and any service started without the
+// NODE_OPTIONS preload — fall back to the old uuid so nothing that works today stops.
+function activeTraceId(): string | undefined {
+  const sc = trace.getSpanContext(context.active());
+  return sc && sc.traceId !== "00000000000000000000000000000000" ? sc.traceId : undefined;
+}
+
+export function currentTraceparent(): string | undefined {
+  const sc = trace.getSpanContext(context.active());
+  if (!sc || sc.traceId === "00000000000000000000000000000000") return undefined;
+  return `00-${sc.traceId}-${sc.spanId}-${sc.traceFlags.toString(16).padStart(2, "0")}`;
+}
+
 export function traceMiddleware() {
   return (req: Request, res: Response, next: NextFunction): void => {
     const incoming = req.header(TRACE_HEADER);
-    const traceId = incoming && incoming.length > 0 ? incoming : uuidv4();
+    // Precedence: the active span (established by the http instrumentation, which has
+    // already extracted any inbound W3C `traceparent`) > the legacy x-trace-id header >
+    // a fresh uuid. x-trace-id stays supported so external callers keep working.
+    const traceId =
+      activeTraceId() ?? (incoming && incoming.length > 0 ? incoming : uuidv4());
     req.traceId = traceId;
     res.setHeader(TRACE_HEADER, traceId);
     // Metadata only — method, path, traceId. NEVER body or query values.

--- a/packages/shared/src/tracing.ts
+++ b/packages/shared/src/tracing.ts
@@ -1,0 +1,88 @@
+// Preload module, loaded via NODE_OPTIONS=--import. NOT exported from index.ts:
+// importing it as a library would start the SDK inside every service and every test.
+//
+// Deliberately has NO relative imports (not even "./logger"). tsx's --import hook
+// resolves this file through a synchronous, worker-mediated resolution path, and
+// pairing that with a *relative* specifier that itself needs further resolution
+// (as "./logger" does, into "winston") deadlocks the process before it ever reaches
+// this file's first statement — reproduced deterministically against tsx 4.23.1 /
+// Node 22.21.1, independent of the relative specifier's extension. Bare package
+// specifiers (below) do not hit this path. See task-2-report.md for the repro.
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { HttpInstrumentation } from "@opentelemetry/instrumentation-http";
+import { ExpressInstrumentation } from "@opentelemetry/instrumentation-express";
+import { RedisInstrumentation } from "@opentelemetry/instrumentation-redis";
+import { PrismaInstrumentation } from "@prisma/instrumentation";
+import { createLogger as createWinston, format, transports } from "winston";
+
+// Inlined rather than imported from "./logger" — see note above. Same shape/output
+// as the shared logger (structured JSON on stdout via winston).
+const log = createWinston({
+  level: process.env.LOG_LEVEL ?? "info",
+  defaultMeta: { service: "tracing" },
+  format: format.combine(format.timestamp(), format.json()),
+  transports: [new transports.Console()],
+});
+
+// The set is explicit, never getNodeAutoInstrumentations(): that bundle includes
+// kafkajs and amqplib, which propagate through broker headers and would compete
+// with this system's envelope-carried context. It also includes fs, which buries
+// a trace in hundreds of spans.
+export const ENABLED_INSTRUMENTATIONS = [
+  "@opentelemetry/instrumentation-http",
+  "@opentelemetry/instrumentation-express",
+  "@opentelemetry/instrumentation-redis",
+  "@prisma/instrumentation",
+] as const;
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __ecomTracingStarted__: boolean | undefined;
+}
+
+// Must live on globalThis, NOT in a module-local variable. The tsx loader evaluates
+// this module more than once, in SEPARATE module registries — a module-local flag is
+// a fresh `false` each time and guards nothing, so the SDK would register duplicate
+// exporters and duplicate instrumentations.
+//
+// globalThis alone is not sufficient, though: verified in Step 6 that `tsx <file>`
+// re-execs itself into a CHILD process (its own respawn-with-loader-flags pattern),
+// and NODE_OPTIONS applies to that child too — so this module evaluates a second
+// time in a genuinely separate process with its own globalThis, which no in-process
+// flag can see across. process.env, unlike globalThis, both survives this module's
+// own re-evaluation AND is inherited by that spawned child (env is copied at spawn
+// time), so it is the guard that actually covers the case this file is loaded for.
+function start(): void {
+  if (globalThis.__ecomTracingStarted__ || process.env.__ECOM_TRACING_STARTED__) return;
+  globalThis.__ecomTracingStarted__ = true;
+  process.env.__ECOM_TRACING_STARTED__ = "true";
+
+  try {
+    const sdk = new NodeSDK({
+      traceExporter: new OTLPTraceExporter(),
+      instrumentations: [
+        new HttpInstrumentation(),
+        new ExpressInstrumentation(),
+        new RedisInstrumentation(),
+        new PrismaInstrumentation(),
+      ],
+    });
+    sdk.start();
+    process.once("SIGTERM", () => {
+      void sdk.shutdown().catch(() => {
+        /* shutdown telemetry must never delay or fail process exit */
+      });
+    });
+    log.info("tracing_started", { service: process.env.OTEL_SERVICE_NAME ?? "unknown" });
+  } catch (e) {
+    // Global constraint 1: instrumentation must never take the process down.
+    log.warn("tracing_start_failed", { message: (e as Error).message });
+  }
+}
+
+export function tracingStarted(): boolean {
+  return globalThis.__ecomTracingStarted__ === true;
+}
+
+start();

--- a/packages/shared/src/tracing.ts
+++ b/packages/shared/src/tracing.ts
@@ -15,6 +15,7 @@ import { ExpressInstrumentation } from "@opentelemetry/instrumentation-express";
 import { RedisInstrumentation } from "@opentelemetry/instrumentation-redis";
 import { PrismaInstrumentation } from "@prisma/instrumentation";
 import { createLogger as createWinston, format, transports } from "winston";
+import { isMainThread } from "node:worker_threads";
 
 // Inlined rather than imported from "./logger" — see note above. Same shape/output
 // as the shared logger (structured JSON on stdout via winston).
@@ -41,22 +42,39 @@ declare global {
   var __ecomTracingStarted__: boolean | undefined;
 }
 
-// Must live on globalThis, NOT in a module-local variable. The tsx loader evaluates
-// this module more than once, in SEPARATE module registries — a module-local flag is
-// a fresh `false` each time and guards nothing, so the SDK would register duplicate
-// exporters and duplicate instrumentations.
+// Skip entirely on a non-main thread before touching any guard state. Only the
+// main thread of a process ever runs application code in this codebase (none of
+// the 8 services spawn worker_threads for request handling). tsx's own loader
+// machinery, however, uses a real worker_threads.Worker internally (its esbuild
+// transform service) — and because that worker is itself spun up from a process
+// whose NODE_OPTIONS still says --import file://tracing.ts, this module gets
+// evaluated inside it too, on a thread that will never carry a single span.
+// Skipping there is a correctness improvement, not just noise reduction: a
+// Worker's globalThis is private to that thread, so its SDK/exporter/instrumentation
+// instances would otherwise be unreachable dead weight for the process's entire
+// lifetime. If a service ever starts using worker_threads for real application
+// work, this line is exactly what to revisit (fix round 1; see task-2-report.md
+// for the probe that found tsx's transform worker logging tracing_started).
 //
-// globalThis alone is not sufficient, though: verified in Step 6 that `tsx <file>`
-// re-execs itself into a CHILD process (its own respawn-with-loader-flags pattern),
-// and NODE_OPTIONS applies to that child too — so this module evaluates a second
-// time in a genuinely separate process with its own globalThis, which no in-process
-// flag can see across. process.env, unlike globalThis, both survives this module's
-// own re-evaluation AND is inherited by that spawned child (env is copied at spawn
-// time), so it is the guard that actually covers the case this file is loaded for.
+// The remaining guard must live on globalThis, NOT a module-local variable. The
+// tsx loader evaluates this module more than once, in SEPARATE module registries
+// — a module-local flag is a fresh `false` each time and guards nothing, so the
+// SDK would register duplicate exporters and duplicate instrumentations.
+//
+// Deliberately NOT process.env: env is inherited by a spawned CHILD process, and
+// tsx respawns `tsx <file>` into exactly such a child (its own respawn-with-
+// loader-flags pattern). An env-based guard set by the parent would be seen as
+// already-true by the child — the one process that actually runs application
+// code — and skip starting its SDK there, leaving tracing silently dead in the
+// process that matters (caught in fix round 1; see task-2-report.md). Each OS
+// process that runs code must start its own SDK: under `tsx src/main.ts` that's
+// legitimately two processes (the tsx CLI's own bootstrap, then the child it
+// respawns into to actually run src/main.ts), so two "tracing_started" lines
+// per service start is the expected, correct count — not a duplicate start.
 function start(): void {
-  if (globalThis.__ecomTracingStarted__ || process.env.__ECOM_TRACING_STARTED__) return;
+  if (!isMainThread) return;
+  if (globalThis.__ecomTracingStarted__) return;
   globalThis.__ecomTracingStarted__ = true;
-  process.env.__ECOM_TRACING_STARTED__ = "true";
 
   try {
     const sdk = new NodeSDK({
@@ -74,7 +92,10 @@ function start(): void {
         /* shutdown telemetry must never delay or fail process exit */
       });
     });
-    log.info("tracing_started", { service: process.env.OTEL_SERVICE_NAME ?? "unknown" });
+    log.info("tracing_started", {
+      service: process.env.OTEL_SERVICE_NAME ?? "unknown",
+      pid: process.pid,
+    });
   } catch (e) {
     // Global constraint 1: instrumentation must never take the process down.
     log.warn("tracing_start_failed", { message: (e as Error).message });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,33 @@ importers:
       '@ecom/contracts':
         specifier: workspace:*
         version: link:../contracts
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
+      '@opentelemetry/exporter-trace-otlp-http':
+        specifier: ^0.221.0
+        version: 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-express':
+        specifier: ^0.69.0
+        version: 0.69.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-http':
+        specifier: ^0.221.0
+        version: 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-redis':
+        specifier: ^0.69.0
+        version: 0.69.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources':
+        specifier: ^2.10.0
+        version: 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node':
+        specifier: ^0.221.0
+        version: 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions':
+        specifier: ^1.43.0
+        version: 1.43.0
+      '@prisma/instrumentation':
+        specifier: ^6.19.3
+        version: 6.19.3(@opentelemetry/api@1.9.1)
       amqplib:
         specifier: ^0.10.4
         version: 0.10.9
@@ -79,6 +106,9 @@ importers:
         specifier: ^3.24.0
         version: 3.25.76
     devDependencies:
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^2.10.0
+        version: 2.10.0(@opentelemetry/api@1.9.1)
       '@types/amqplib':
         specifier: ^0.10.5
         version: 0.10.8
@@ -765,6 +795,15 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@grpc/grpc-js@1.14.4':
+    resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.8.1':
+    resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -788,13 +827,208 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@opentelemetry/api-logs@0.221.0':
+    resolution: {integrity: sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/configuration@0.221.0':
+    resolution: {integrity: sha512-uE9y56Zdi9Gt/RdxYnVOo3YmFZkKJJMA0gqtBe8wh8gdtF5Asqe+Oh/TWiDtFb1s+31jNY4CWgnfIB1KOITfFA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
+  '@opentelemetry/context-async-hooks@2.10.0':
+    resolution: {integrity: sha512-bvyMcgLEkozzSzpEEEo1OMoeQ97bxj6Qs2uN3mPrSdDvObMI1myffD/BPqcLlzZO9//d1SqQA/WPw7Cz2AiqhA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.10.0':
+    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.221.0':
+    resolution: {integrity: sha512-txG1G0IrYSsKKMeiWZfj/i5cQmWB+h+hf3HzPpF3RqZVwp+iQQEIsv8Vtmzy6RWVdHdJZfygmVrBI39YTBvWcw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-http@0.221.0':
+    resolution: {integrity: sha512-nKXkr4Tomi6fjYVOf+ytcW3dZAVr4v4Bv5gsT6dr2gvpUPJpKgHB4XbMufMsPotRE3g0XH2GwVVCkN2w6SON+Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.221.0':
+    resolution: {integrity: sha512-AH6EY+47gXFaWYgG3hfeOneGiE9xIZGtDBk+9g0sM8NZWzsQhhmqPbQQXJzS7pyCh5jRRr2nYNXVrkCmoojRvQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.221.0':
+    resolution: {integrity: sha512-KOgCtO15FC6C1T/xOqBcr7EyUs7B+7yomGNb5Y97d3s38rPbCCk5sewkmE2b0/itOkQ/PptX8CLlD+kn2mEtTg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.221.0':
+    resolution: {integrity: sha512-sRfCKbOzgy8xZQV2as0RzIZlnCmCseCKZGLfRcrpo2CBngJDr+rPtX0zkG0+oUCV5kfQPUoW3W3C96Ag3Y/Clg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.221.0':
+    resolution: {integrity: sha512-YMF4LveY2I3yhw61rn6nmC9FE8U24IZHPeKU1Duc5+sbwjMd8FwZAwba318ImdThCg/HuVQvhm2y6bfgNPnfYg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-prometheus@0.221.0':
+    resolution: {integrity: sha512-kW79a20qWESIuAdDrxzg9WKM98twV/NBWBFRAH57ap/+ssZhiCo0hckzKT0zpuwR/gSHrFAQhJL0bYDrnEM34g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.221.0':
+    resolution: {integrity: sha512-zXminlZedtq9LvOW64CnNkOqk15zV75k8JgtdTuWFge6+jk2m4GmAUm6L2eIiG1o2a2bZxXw2PDrszm+bps0IA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.221.0':
+    resolution: {integrity: sha512-AySXiKoC+meiWm6zdVj5T2LnPDZuatveBby1cMOeQteIWsYXAUxs8Sru13G2pVSPrUXz6vF+og7QVBX6GdC/oQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.221.0':
+    resolution: {integrity: sha512-Z9i2T7vgZbWe9rSLYxXVIbeW+XyzUq4rZanW3ZyVNwVDqCsh0EJKUgBWWQ0CZfeuUA+RQPzKgJQHMuWAUnKqXw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-zipkin@2.10.0':
+    resolution: {integrity: sha512-7gsvgf0UDoJ4l9ObrwBmz5G/ZogiPk+lq+g5GpLp24YQF/vPM/BSsnOfcLnfinast5ASUgLo78uSC/ObjlnXgg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/instrumentation-express@0.69.0':
+    resolution: {integrity: sha512-91pHMujQgDyhEQrdg8RriMBrRZ/qPaJ0Y2dopQ6lHjW5YjoeytWi8ruM//T6f5o0D95hnqRlv79Pel1lGPqaYg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-http@0.221.0':
+    resolution: {integrity: sha512-oIP91CPIANuYr09tGFElPFKAh6JUar+awJf1kBRYlaeo9b0gDwZHEB2zBfFlvdNFHm0wAVutMZODVi5smKT30g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-redis@0.69.0':
+    resolution: {integrity: sha512-lyCIEW89cYhMwaUSMBzsKHdwH2wOoqmuwXOARJneo9UL55govLIUCbYYAJ457oM8kdKADymlY4+SUW0DKQeIHw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.221.0':
+    resolution: {integrity: sha512-cCk80Z/iRDf/5gfsKMB4f74LqVA5yKETB/9ojPzVW/6/f70iu89nJvGxsFCxx4XfSohaOofkU19kiYm84AiAlw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.221.0':
+    resolution: {integrity: sha512-UFPIq80OH3Ns/oPFHRj14d4DTOxUo+MUFU8hUiCq5jTqFhdeJnfVSANHT+xp92409cA+oxzvlZCe6NM1wvCuBA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.221.0':
+    resolution: {integrity: sha512-rQDmNgyiGCTrescjnzH2ntVyUKVIq6I2UjuK8+stT/Xg0ZOT71FVJqwjFdspQl6Yol/Yqsut9bDo+ame8oTmDQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.221.0':
+    resolution: {integrity: sha512-lg6lkOU08Az23jVcn/0Els9HP+V8PnR4Km6p0KgpTggS0n/WuhnmY64rSh83Of9iR9nD+dpWr6adlcX8KzAwjg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/propagator-b3@2.10.0':
+    resolution: {integrity: sha512-GnA5B24H+1w8BO21J0q+IWNB0z1v+AGbcquTdIt/dufibhnhgxaA8YKvz0I3akRZhB1jHT+/tlzK+qlAjEDybQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/propagator-jaeger@2.10.0':
+    resolution: {integrity: sha512-yw/IX8DL470dSMZJoE82ScfYGp7JWZ/G8kFJo35ZILUVTB2jFPTOaioN+8s09pH0RHsWNhweVZb+ZnjJJpCChg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/redis-common@0.38.3':
+    resolution: {integrity: sha512-VCghU1JYs/4gP6Gqf/xro9MEsZ7LrMv2uONVsaESKL38ZOB9BqnI98FfS23wjMnHlpuE+TTaWSoAVNpTwYXzjw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+
+  '@opentelemetry/resources@2.10.0':
+    resolution: {integrity: sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.221.0':
+    resolution: {integrity: sha512-FaDcazjyMp7TZZZAsqbo4IkovP0UegoCu0EBkiNt+qCqvUf7FPAsfcrZ3+ZEkKgXZ/jHafop+JoGPDk3A0SmLg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.10.0':
+    resolution: {integrity: sha512-t6r1VSvXNtSDnPXU1FbZeetJb7yyovHmgu0wRSoftxtE0g2rSNhQZQUy69sRUCL+iioJpX8SN/S6wq6ZtvLySQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-node@0.221.0':
+    resolution: {integrity: sha512-UbYuvtBrQQB5Prsh9KOKy4kxzexFxfMs5MkteHeWMoswsEB7kiNhyUVkAOFW/qsEzNHtrkgyghrD2ilZJa+5YA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.10.0':
+    resolution: {integrity: sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@2.10.0':
+    resolution: {integrity: sha512-GZK/G6oZyBLGlH1pUgeDch7D91KoHd2uotUGIkWCPi9GI5T9X0p4L7nNAMDR1BQjkRYoDqo+ddfVx9t5Uhys+Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.10.0':
+    resolution: {integrity: sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
@@ -828,6 +1062,38 @@ packages:
 
   '@prisma/get-platform@6.19.3':
     resolution: {integrity: sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==}
+
+  '@prisma/instrumentation@6.19.3':
+    resolution: {integrity: sha512-gwU1D4pxrtBZXINZwSseEal+h8OghvIVZIH3VRv6+vPFAkZk1ykFUVcOhhboBc5WmhoD42NTJjla2i7GFNcZWA==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.8
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@redis/bloom@1.2.0':
     resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
@@ -1187,6 +1453,10 @@ packages:
     resolution: {integrity: sha512-jwSftI4QjS3mizvnSnOrPGYiUnm1vI2OP1iXeOUz5pb74Ua0nbf6nPyyTzuiCLEE3fMpaJORXh2K/TQ08H5xGA==}
     engines: {node: '>=10'}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -1293,6 +1563,13 @@ packages:
 
   citty@0.2.2:
     resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
+
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   cluster-key-slot@1.1.2:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
@@ -1437,6 +1714,9 @@ packages:
   effect@3.21.0:
     resolution: {integrity: sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==}
 
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
@@ -1459,6 +1739,9 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
@@ -1476,6 +1759,10 @@ packages:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -1634,6 +1921,9 @@ packages:
     resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
     engines: {node: '>=14.0.0'}
 
+  forwarded-parse@2.1.2:
+    resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -1653,6 +1943,10 @@ packages:
   generic-pool@3.9.0:
     resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
     engines: {node: '>= 4'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -1726,6 +2020,10 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-in-the-middle@3.3.2:
+    resolution: {integrity: sha512-jTd2FfOgOWOdgjkHuk/1Ms8VKFXkPs15ymYBETw1sAOrO/dY3XeGVRWir9qBbw7pXr0T2eTFwfCZ+N02HmiNGA==}
+    engines: {node: '>=18'}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -1740,6 +2038,10 @@ packages:
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -1805,6 +2107,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
 
@@ -1832,6 +2137,9 @@ packages:
   logform@2.7.0:
     resolution: {integrity: sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==}
     engines: {node: '>= 12.0.0'}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -1882,6 +2190,9 @@ packages:
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -2069,6 +2380,10 @@ packages:
     resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
     engines: {node: ^16 || ^18 || >=20}
 
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
+    engines: {node: '>=12.0.0'}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -2108,6 +2423,14 @@ packages:
 
   redis@4.7.1:
     resolution: {integrity: sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
@@ -2195,8 +2518,16 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -2400,6 +2731,10 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -2407,8 +2742,25 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.3:
+    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -2620,6 +2972,18 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@grpc/grpc-js@1.14.4':
+    dependencies:
+      '@grpc/proto-loader': 0.8.1
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.8.1':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.6.5
+      yargs: 17.7.3
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -2638,9 +3002,263 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
+  '@js-sdsl/ordered-map@4.4.2': {}
+
   '@noble/hashes@1.8.0': {}
 
+  '@opentelemetry/api-logs@0.221.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
   '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/configuration@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      yaml: 2.9.0
+
+  '@opentelemetry/context-async-hooks@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-logs-otlp-http@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/exporter-metrics-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/exporter-metrics-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-prometheus@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-zipkin@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/instrumentation-express@0.69.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-http@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+      forwarded-parse: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-redis@0.69.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/redis-common': 0.38.3
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      import-in-the-middle: 3.3.2
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/otlp-exporter-base@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/propagator-b3@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/propagator-jaeger@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/redis-common@0.38.3': {}
+
+  '@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-node@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/configuration': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/context-async-hooks': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-grpc': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-proto': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-grpc': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-proto': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-prometheus': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-proto': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-zipkin': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-b3': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-jaeger': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace-node@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
@@ -2680,6 +3298,33 @@ snapshots:
   '@prisma/get-platform@6.19.3':
     dependencies:
       '@prisma/debug': 6.19.3
+
+  '@prisma/instrumentation@6.19.3(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.2': {}
 
   '@redis/bloom@1.2.0(@redis/client@1.6.1)':
     dependencies:
@@ -3052,6 +3697,8 @@ snapshots:
       buffer-more-ints: 1.0.0
       url-parse: 1.5.10
 
+  ansi-regex@5.0.1: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
@@ -3166,6 +3813,14 @@ snapshots:
 
   citty@0.2.2: {}
 
+  cjs-module-lexer@2.2.0: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   cluster-key-slot@1.1.2: {}
 
   color-convert@2.0.1:
@@ -3276,6 +3931,8 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
+  emoji-regex@8.0.0: {}
+
   empathic@2.0.0: {}
 
   enabled@2.0.0: {}
@@ -3287,6 +3944,8 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.2:
     dependencies:
@@ -3353,6 +4012,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.28.1
       '@esbuild/win32-ia32': 0.28.1
       '@esbuild/win32-x64': 0.28.1
+
+  escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
 
@@ -3554,6 +4215,8 @@ snapshots:
       dezalgo: 1.0.4
       once: 1.4.0
 
+  forwarded-parse@2.1.2: {}
+
   forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
@@ -3564,6 +4227,8 @@ snapshots:
   function-bind@1.1.2: {}
 
   generic-pool@3.9.0: {}
+
+  get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -3654,6 +4319,12 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-in-the-middle@3.3.2:
+    dependencies:
+      cjs-module-lexer: 2.2.0
+      es-module-lexer: 2.3.1
+      module-details-from-path: 1.0.4
+
   imurmurhash@0.1.4: {}
 
   inherits@2.0.4: {}
@@ -3661,6 +4332,8 @@ snapshots:
   ipaddr.js@1.9.1: {}
 
   is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-glob@4.0.3:
     dependencies:
@@ -3727,6 +4400,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.camelcase@4.3.0: {}
+
   lodash.includes@4.3.0: {}
 
   lodash.isboolean@3.0.3: {}
@@ -3751,6 +4426,8 @@ snapshots:
       ms: 2.1.3
       safe-stable-stringify: 2.5.0
       triple-beam: 1.4.1
+
+  long@5.3.2: {}
 
   loupe@3.2.1: {}
 
@@ -3788,6 +4465,8 @@ snapshots:
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.16
+
+  module-details-from-path@1.0.4: {}
 
   ms@2.0.0: {}
 
@@ -3945,6 +4624,20 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       tdigest: 0.1.2
 
+  protobufjs@7.6.5:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 22.20.1
+      long: 5.3.2
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -3991,6 +4684,15 @@ snapshots:
       '@redis/json': 1.0.7(@redis/client@1.6.1)
       '@redis/search': 1.2.0(@redis/client@1.6.1)
       '@redis/time-series': 1.1.0(@redis/client@1.6.1)
+
+  require-directory@2.1.1: {}
+
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   requires-port@1.0.0: {}
 
@@ -4112,9 +4814,19 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
 
   strip-json-comments@3.1.1: {}
 
@@ -4321,11 +5033,33 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrappy@1.0.2: {}
 
   xtend@4.0.2: {}
 
+  y18n@5.0.8: {}
+
   yallist@4.0.0: {}
+
+  yaml@2.9.0: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.3:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,6 +401,12 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^2.10.0
+        version: 2.10.0(@opentelemetry/api@1.9.1)
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.25

--- a/services/catalog/prisma/migrations/20260729104714_add_traceparent_to_outbox/migration.sql
+++ b/services/catalog/prisma/migrations/20260729104714_add_traceparent_to_outbox/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Outbox" ADD COLUMN     "traceparent" TEXT;

--- a/services/catalog/prisma/schema.prisma
+++ b/services/catalog/prisma/schema.prisma
@@ -63,6 +63,7 @@ model Outbox {
   type          String
   version       Int       @default(1)
   traceId       String
+  traceparent   String?
   producer      String
   payload       Json
   occurredAt    DateTime  @default(now())

--- a/services/catalog/src/tx-adapters.ts
+++ b/services/catalog/src/tx-adapters.ts
@@ -1,4 +1,5 @@
 import { Prisma } from "./generated/prisma";
+import { currentTraceparent } from "@ecom/shared";
 import type { ProductWriteTx } from "./product";
 
 export function productTx(tx: Prisma.TransactionClient, traceId: string): ProductWriteTx {
@@ -45,6 +46,7 @@ export function productTx(tx: Prisma.TransactionClient, traceId: string): Produc
           aggregateId: productId,
           type,
           traceId,
+          traceparent: currentTraceparent(),
           producer: "catalog",
           payload: payload as Prisma.InputJsonValue,
         },

--- a/services/hello/prisma/migrations/20260729104652_add_traceparent_to_outbox/migration.sql
+++ b/services/hello/prisma/migrations/20260729104652_add_traceparent_to_outbox/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Outbox" ADD COLUMN     "traceparent" TEXT;

--- a/services/hello/prisma/schema.prisma
+++ b/services/hello/prisma/schema.prisma
@@ -20,6 +20,7 @@ model Outbox {
   type          String
   version       Int       @default(1)
   traceId       String
+  traceparent   String?
   producer      String
   payload       Json
   occurredAt    DateTime  @default(now())

--- a/services/hello/src/app.ts
+++ b/services/hello/src/app.ts
@@ -5,6 +5,7 @@ import {
   createHealthRouter,
   createMetrics,
   getRedis,
+  currentTraceparent,
   type Metrics,
 } from "@ecom/shared";
 import { HELLO_CREATED, HelloCreatedPayloadSchema } from "@ecom/contracts";
@@ -46,6 +47,7 @@ export function createApp(deps: { metrics?: Metrics } = {}): express.Application
             type: HELLO_CREATED,
             version: 1,
             traceId: req.traceId,
+            traceparent: currentTraceparent(),
             producer: "hello",
             payload,
           },

--- a/services/identity/prisma/migrations/20260729104725_add_traceparent_to_outbox/migration.sql
+++ b/services/identity/prisma/migrations/20260729104725_add_traceparent_to_outbox/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Outbox" ADD COLUMN     "traceparent" TEXT;

--- a/services/identity/prisma/schema.prisma
+++ b/services/identity/prisma/schema.prisma
@@ -73,6 +73,7 @@ model Outbox {
   type          String
   version       Int       @default(1)
   traceId       String
+  traceparent   String?
   producer      String
   payload       Json
   occurredAt    DateTime  @default(now())

--- a/services/identity/src/tx-adapters.ts
+++ b/services/identity/src/tx-adapters.ts
@@ -1,4 +1,5 @@
 import { Prisma } from "./generated/prisma";
+import { currentTraceparent } from "@ecom/shared";
 import type { SessionTx } from "./sessions";
 
 export function sessionTx(tx: Prisma.TransactionClient): SessionTx {
@@ -54,6 +55,7 @@ export function outboxEnqueue(
       aggregateId,
       type,
       traceId,
+      traceparent: currentTraceparent(),
       producer: "identity",
       payload: payload as Prisma.InputJsonValue,
     },

--- a/services/inventory/prisma/migrations/20260729104659_add_traceparent_to_outbox/migration.sql
+++ b/services/inventory/prisma/migrations/20260729104659_add_traceparent_to_outbox/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Outbox" ADD COLUMN     "traceparent" TEXT;

--- a/services/inventory/prisma/schema.prisma
+++ b/services/inventory/prisma/schema.prisma
@@ -42,6 +42,7 @@ model Outbox {
   type          String
   version       Int       @default(1)
   traceId       String
+  traceparent   String?
   producer      String
   payload       Json
   occurredAt    DateTime  @default(now())

--- a/services/inventory/src/sweeper.ts
+++ b/services/inventory/src/sweeper.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "crypto";
 import { Prisma } from "./generated/prisma";
-import { createLogger } from "@ecom/shared";
+import { createLogger, currentTraceparent } from "@ecom/shared";
 import { prisma } from "./db";
 import { releaseRows, type ReleaseCoreTx } from "./release";
 
@@ -28,6 +28,7 @@ function sweepTx(tx: Prisma.TransactionClient, traceId: string): ReleaseCoreTx {
           aggregateId: orderId,
           type,
           traceId,
+          traceparent: currentTraceparent(),
           producer: "inventory",
           payload: payload as Prisma.InputJsonValue,
         },

--- a/services/inventory/src/tx-adapters.ts
+++ b/services/inventory/src/tx-adapters.ts
@@ -1,4 +1,5 @@
 import { Prisma } from "./generated/prisma";
+import { currentTraceparent } from "@ecom/shared";
 import type { ReserveTx } from "./reserve";
 import type { ReleaseTx } from "./release";
 import type { ConsumeTx } from "./consume";
@@ -45,6 +46,7 @@ export function reserveTx(tx: Prisma.TransactionClient, traceId: string): Reserv
           aggregateId: orderId,
           type,
           traceId,
+          traceparent: currentTraceparent(),
           producer: "inventory",
           payload: payload as Prisma.InputJsonValue,
         },
@@ -89,6 +91,7 @@ export function releaseTx(tx: Prisma.TransactionClient, traceId: string): Releas
           aggregateId: orderId,
           type,
           traceId,
+          traceparent: currentTraceparent(),
           producer: "inventory",
           payload: payload as Prisma.InputJsonValue,
         },

--- a/services/notification/prisma/migrations/20260729104721_add_traceparent_to_outbox/migration.sql
+++ b/services/notification/prisma/migrations/20260729104721_add_traceparent_to_outbox/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Outbox" ADD COLUMN     "traceparent" TEXT;

--- a/services/notification/prisma/schema.prisma
+++ b/services/notification/prisma/schema.prisma
@@ -38,6 +38,7 @@ model Outbox {
   type          String
   version       Int       @default(1)
   traceId       String
+  traceparent   String?
   producer      String
   payload       Json
   occurredAt    DateTime  @default(now())

--- a/services/notification/src/tx-adapters.ts
+++ b/services/notification/src/tx-adapters.ts
@@ -1,4 +1,5 @@
 import { Prisma } from "./generated/prisma";
+import { currentTraceparent } from "@ecom/shared";
 import type { DispatchTx } from "./dispatcher";
 
 export function dispatchTx(tx: Prisma.TransactionClient, traceId: string): DispatchTx {
@@ -29,6 +30,7 @@ export function dispatchTx(tx: Prisma.TransactionClient, traceId: string): Dispa
           aggregateId,
           type,
           traceId,
+          traceparent: currentTraceparent(),
           producer: "notification",
           payload: payload as Prisma.InputJsonValue,
         },

--- a/services/order/package.json
+++ b/services/order/package.json
@@ -18,6 +18,8 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/sdk-trace-node": "^2.10.0",
     "@types/express": "^4.17.21",
     "@types/pg": "^8.20.0",
     "@types/supertest": "^6.0.2",

--- a/services/order/prisma/migrations/20260729104702_add_traceparent_to_outbox/migration.sql
+++ b/services/order/prisma/migrations/20260729104702_add_traceparent_to_outbox/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Outbox" ADD COLUMN     "traceparent" TEXT;

--- a/services/order/prisma/schema.prisma
+++ b/services/order/prisma/schema.prisma
@@ -68,6 +68,7 @@ model Outbox {
   type          String
   version       Int       @default(1)
   traceId       String
+  traceparent   String?
   producer      String
   payload       Json
   occurredAt    DateTime  @default(now())

--- a/services/order/src/__tests__/outbox-traceparent.int.test.ts
+++ b/services/order/src/__tests__/outbox-traceparent.int.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { context, trace, TraceFlags, type SpanContext } from "@opentelemetry/api";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { randomUUID } from "crypto";
+import { prisma } from "../db";
+import { placeOrderTx } from "../tx-adapters";
+
+// @opentelemetry/api's default ContextManager is a no-op: context.with(ctx, fn) just
+// calls fn() without making ctx active, so context.active() inside fn (which is what
+// currentTraceparent() reads) would keep returning the empty ROOT_CONTEXT no matter
+// what SpanContext this test injects. Production processes get a real ContextManager
+// for free from tracing.ts's NodeSDK.start() (the NODE_OPTIONS preload); this test
+// runs standalone, so it registers its own — same test-only pattern Task 3 used in
+// packages/shared/src/__tests__/trace.test.ts. Registering twice in the same process
+// is harmless (@opentelemetry/api logs and ignores a duplicate registration).
+new NodeTracerProvider().register();
+
+const TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736";
+const SPAN_ID = "00f067aa0ba902b7";
+
+describe("outbox rows capture the active traceparent (integration)", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("writes the active span's context onto the row", async () => {
+    const orderId = `o_${randomUUID()}`;
+    const sc: SpanContext = {
+      traceId: TRACE_ID,
+      spanId: SPAN_ID,
+      traceFlags: TraceFlags.SAMPLED,
+      isRemote: false,
+    };
+    await context.with(trace.setSpanContext(context.active(), sc), async () => {
+      await prisma.$transaction(async (tx) => {
+        await placeOrderTx(tx, "t").enqueue("order.placed", orderId, {});
+      });
+    });
+    const row = await prisma.outbox.findFirst({ where: { aggregateId: orderId } });
+    expect(row?.traceparent).toBe(`00-${TRACE_ID}-${SPAN_ID}-01`);
+  });
+
+  it("writes null when there is no active span, rather than throwing", async () => {
+    const orderId = `o_${randomUUID()}`;
+    await prisma.$transaction(async (tx) => {
+      await placeOrderTx(tx, "t").enqueue("order.placed", orderId, {});
+    });
+    const row = await prisma.outbox.findFirst({ where: { aggregateId: orderId } });
+    expect(row?.traceparent).toBeNull();
+  });
+});

--- a/services/order/src/tx-adapters.ts
+++ b/services/order/src/tx-adapters.ts
@@ -1,4 +1,5 @@
 import { Prisma } from "./generated/prisma";
+import { currentTraceparent } from "@ecom/shared";
 import type { PlaceOrderTx } from "./place-order";
 import type { TransitionTx } from "./transition";
 
@@ -40,6 +41,7 @@ export function placeOrderTx(
           aggregateId: orderId,
           type,
           traceId,
+          traceparent: currentTraceparent(),
           producer: "order",
           payload: payload as Prisma.InputJsonValue,
         },
@@ -86,6 +88,7 @@ export function transitionTx(
           aggregateId: orderId,
           type,
           traceId,
+          traceparent: currentTraceparent(),
           producer: "order",
           payload: payload as Prisma.InputJsonValue,
         },

--- a/services/payment/prisma/migrations/20260729104710_add_traceparent_to_outbox/migration.sql
+++ b/services/payment/prisma/migrations/20260729104710_add_traceparent_to_outbox/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Outbox" ADD COLUMN     "traceparent" TEXT;

--- a/services/payment/prisma/schema.prisma
+++ b/services/payment/prisma/schema.prisma
@@ -45,6 +45,7 @@ model Outbox {
   type          String
   version       Int       @default(1)
   traceId       String
+  traceparent   String?
   producer      String
   payload       Json
   occurredAt    DateTime  @default(now())

--- a/services/payment/src/tx-adapters.ts
+++ b/services/payment/src/tx-adapters.ts
@@ -1,4 +1,5 @@
 import { Prisma } from "./generated/prisma";
+import { currentTraceparent } from "@ecom/shared";
 import type { ChargeTx } from "./charge";
 import type { ResolveTx } from "./resolve";
 
@@ -34,6 +35,7 @@ export function chargeTx(tx: Prisma.TransactionClient, traceId: string): ChargeT
           aggregateId: orderId,
           type,
           traceId,
+          traceparent: currentTraceparent(),
           producer: "payment",
           payload: payload as Prisma.InputJsonValue,
         },
@@ -71,6 +73,7 @@ export function resolveTx(tx: Prisma.TransactionClient, traceId: string): Resolv
           aggregateId: orderId,
           type,
           traceId,
+          traceparent: currentTraceparent(),
           producer: "payment",
           payload: payload as Prisma.InputJsonValue,
         },


### PR DESCRIPTION
Third slice of Phase 7: `7a` debt → `7b` metrics → **`7c` tracing** → `7d` verification.

7b answered "is the system healthy?". It could not answer "what happened to **this** order?". This slice makes one checkout into one Jaeger trace.

## What this ships

`traceparent` rides **inside the event envelope**, not in broker headers — because this system round-trips events through three places headers do not survive: a Postgres outbox row, a raw-bytes Kafka DLQ park, and a Rabbit replay that re-parses through the schema. The field is optional, so events already in flight are not dead-lettered by the deploy.

`traceId` is now the W3C trace ID, so a value copied from a log line pastes straight into Jaeger's search box. The SDK loads via a `NODE_OPTIONS=--import` preload. Jaeger all-in-one joins compose with its OTLP ports deliberately unpublished — only the UI is reachable.

Spans sit at three seams. The outbox relay emits a PRODUCER span parented to the context stored on the row, and publishes **its own** context — so the relay's polling delay shows up as a visible gap instead of time silently folded into the consumer. Both broker legs emit CONSUMER spans parented to that, and the handler runs *inside* its consumer span so its database work hangs off the right node.

## Verification

| Gate | Result |
|---|---|
| Per-task review (9 tasks) | all resolved; 4 needed fix rounds |
| Whole-branch review | **MERGE**; one Important found and fixed, not deferred |
| `pnpm -r typecheck` / `pnpm format:check` | clean |
| Tests | 88 in `packages/shared`, 384 workspace-wide |
| End-to-end acceptance | run for real **twice** — before and after the final fix |

Acceptance was verified against Jaeger's HTTP API rather than the UI: trace `c64d3757…`, 340 spans, all five services (order 146 · notification 86 · inventory 53 · payment 38 · gateway 17). The payment hop was **confirmed** to travel over RabbitMQ via `otel.scope.name` on its consumer span, not inferred — that was the most likely silent gap. Relay gap visible at all six relay-mediated hops, 77–399ms, inside the 500ms poll window.

## Two bugs mattered, and no test caught either

**Tracing was entirely non-functional at one point.** The SDK idempotency guard was keyed on `process.env`, which is inherited at spawn. tsx respawns into a child, so the parent started the SDK and set the flag; the child — where the application actually runs — saw the flag and skipped startup. The acceptance criterion in use, *"logs exactly once,"* was the **signature** of the bug: one log line meant one process started the SDK, and it was the wrong one. Now guarded on `globalThis`, and protected by a committed test that spawns a real child process through the tsx binary and asserts a non-zero trace ID.

**Consumer spans were never made active for the handler.** Everything inside a handler parented to the *upstream relay's* span: Prisma spans one level too high, consumer spans rendering as childless leaves, and consumer-side outbox writes capturing the relay's span id so the next hop parented to a sibling rather than a child. Every existing test passed against it — which is why nine task reviews missed it. The review suggested deferring; it was fixed, because trace fidelity is what this slice sells. Post-fix, 15 spans parent to consumer spans where there were 0.

## Plan defects found during execution

The plan was wrong seven times — two caught in pre-flight, five by the implementers. The sharpest: a test that could not pass under *any* implementation (`NoopContextManager` makes `context.with()` a passthrough); a test exercising `undefined` where Prisma returns `null`; a completeness check that printed success unconditionally, including against unedited code; and a snippet covering only the producer side, which would have left the plan's own "most important step" with nothing to break.

**Six plan-supplied tests would have passed against broken implementations.** Requiring every test to be proven to fail when its wiring is removed is the only reason that surfaced instead of shipping.

## Follow-ups (none blocking)

- **`hello`'s container CrashLoops** on a pre-existing corepack issue — second slice running degraded. Its spans and its Prometheus target are both absent. Worth fixing before 7d.
- 37 stale reservations keep inventory's sweeper retrying, inflating the measured idle span floor from ~5,725/min to 13,367/min. Clear before 7d sizes sampling.
- `order-stream.e2e.test.ts` passes in isolation, fails in full-suite runs — shared Kafka consumer-group state, same class as 7b's durable-topic replay issue.
- 3 SDK instances start across tsx realms; correct but wasteful.
- Containers do not `migrate deploy` on start, so the seven `add_traceparent_to_outbox` migrations must be applied before new images roll. The column is additive-nullable, so old-code/new-DB is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018awLdJptXSWufyxU5LEMJh