### PR TITLE
Phase 8a — storefront foundation + catalogue

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Storefront</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,7 +14,8 @@
     "@tanstack/react-query": "5.101.4",
     "react": "19.2.8",
     "react-dom": "19.2.8",
-    "react-router": "8.3.0"
+    "react-router": "8.3.0",
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "4.3.3",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@ecom/web",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -p tsconfig.json --noEmit && vite build",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@ecom/contracts": "workspace:*",
+    "@tanstack/react-query": "5.101.4",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
+    "react-router": "8.3.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "4.3.3",
+    "@testing-library/jest-dom": "7.0.0",
+    "@testing-library/react": "16.3.2",
+    "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.0",
+    "@vitejs/plugin-react": "6.0.5",
+    "jsdom": "30.0.1",
+    "tailwindcss": "4.3.3",
+    "vite": "8.2.0"
+  }
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,7 +1,11 @@
 import { createBrowserRouter, RouterProvider } from "react-router";
 import { Home } from "./routes/Home";
+import { Product } from "./routes/Product";
 
-const router = createBrowserRouter([{ path: "/", element: <Home /> }]);
+const router = createBrowserRouter([
+  { path: "/", element: <Home /> },
+  { path: "/products/:id", element: <Product /> },
+]);
 
 export function App() {
   return <RouterProvider router={router} />;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,3 +1,8 @@
+import { createBrowserRouter, RouterProvider } from "react-router";
+import { Home } from "./routes/Home";
+
+const router = createBrowserRouter([{ path: "/", element: <Home /> }]);
+
 export function App() {
-  return <h1>Storefront</h1>;
+  return <RouterProvider router={router} />;
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,0 +1,3 @@
+export function App() {
+  return <h1>Storefront</h1>;
+}

--- a/apps/web/src/__tests__/smoke.test.tsx
+++ b/apps/web/src/__tests__/smoke.test.tsx
@@ -1,7 +1,0 @@
-import { render, screen } from "@testing-library/react";
-import { App } from "../App";
-
-it("renders the app shell", () => {
-  render(<App />);
-  expect(screen.getByRole("heading", { name: "Storefront" })).toBeInTheDocument();
-});

--- a/apps/web/src/__tests__/smoke.test.tsx
+++ b/apps/web/src/__tests__/smoke.test.tsx
@@ -1,0 +1,7 @@
+import { render, screen } from "@testing-library/react";
+import { App } from "../App";
+
+it("renders the app shell", () => {
+  render(<App />);
+  expect(screen.getByRole("heading", { name: "Storefront" })).toBeInTheDocument();
+});

--- a/apps/web/src/api/__tests__/products.test.ts
+++ b/apps/web/src/api/__tests__/products.test.ts
@@ -1,0 +1,47 @@
+import { getProduct, listProducts } from "../products";
+
+// The storefront serves a page at /products/:id and the gateway serves a resource at
+// /products. If the client asked for the second at the origin root, the dev-server proxy
+// would answer the first as well, and a hard refresh on a product page would render JSON.
+// These assertions pin the two URL spaces apart.
+function stubFetch(body: unknown) {
+  const spy = vi.fn<typeof fetch>(
+    async () => new Response(JSON.stringify(body), { status: 200 })
+  );
+  vi.stubGlobal("fetch", spy);
+  return spy;
+}
+afterEach(() => vi.unstubAllGlobals());
+
+it("lists products under the /api prefix, not at the origin root", async () => {
+  const spy = stubFetch([]);
+  await listProducts();
+  expect(spy.mock.calls[0][0]).toBe("/api/products");
+});
+
+it("fetches a product under the /api prefix, never shadowing the page route", async () => {
+  const spy = stubFetch({
+    id: "p1",
+    type: "ELECTRONICS",
+    name: "Widget",
+    price: 900,
+    version: 1,
+    attributes: {},
+  });
+  await getProduct("p1");
+  expect(spy.mock.calls[0][0]).toBe("/api/products/p1");
+  expect(spy.mock.calls[0][0]).not.toBe("/products/p1");
+});
+
+it("encodes the id so a crafted id cannot escape the path", async () => {
+  const spy = stubFetch({
+    id: "a/b",
+    type: "ELECTRONICS",
+    name: "Widget",
+    price: 900,
+    version: 1,
+    attributes: {},
+  });
+  await getProduct("a/b?x=1");
+  expect(spy.mock.calls[0][0]).toBe("/api/products/a%2Fb%3Fx%3D1");
+});

--- a/apps/web/src/api/__tests__/request.test.ts
+++ b/apps/web/src/api/__tests__/request.test.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+import { request } from "../request";
+import { HttpError, NetworkError, SchemaMismatchError } from "../errors";
+import { makeQueryClient } from "../queryClient";
+
+const schema = z.object({ id: z.string() });
+
+function mockFetch(impl: () => Promise<Response> | never) {
+  vi.stubGlobal("fetch", vi.fn(impl));
+}
+afterEach(() => vi.unstubAllGlobals());
+
+it("returns parsed data on a valid response", async () => {
+  mockFetch(async () => new Response(JSON.stringify({ id: "p1" }), { status: 200 }));
+  await expect(request("/products", schema)).resolves.toEqual({ id: "p1" });
+});
+
+it("throws HttpError carrying the status on a non-2xx", async () => {
+  mockFetch(async () => new Response("nope", { status: 404 }));
+  const err = await request("/products", schema).catch((e) => e);
+  expect(err).toBeInstanceOf(HttpError);
+  expect((err as HttpError).status).toBe(404);
+});
+
+it("throws NetworkError when fetch itself rejects", async () => {
+  mockFetch(() => Promise.reject(new TypeError("failed to fetch")));
+  await expect(request("/products", schema)).rejects.toBeInstanceOf(NetworkError);
+});
+
+// The drift alarm. A shape mismatch is a BUG, not a user-facing condition, so it must be
+// distinguishable from a 4xx or a dropped connection.
+it("throws SchemaMismatchError when the body does not match the schema", async () => {
+  mockFetch(async () => new Response(JSON.stringify({ id: 42 }), { status: 200 }));
+  await expect(request("/products", schema)).rejects.toBeInstanceOf(SchemaMismatchError);
+});
+
+it("requests a same-origin path, never an absolute gateway URL", async () => {
+  // Typed as `fetch` so `mock.calls[0][0]` is the URL argument. An untyped `vi.fn(async () =>
+  // …)` infers a zero-parameter call tuple, and the assertion below stops compiling.
+  const spy = vi.fn<typeof fetch>(
+    async () => new Response(JSON.stringify({ id: "p1" }), { status: 200 })
+  );
+  vi.stubGlobal("fetch", spy);
+  await request("/products", schema);
+  expect(spy.mock.calls[0][0]).toBe("/products");
+});
+
+it("retries network failures but never schema mismatches or 4xx", () => {
+  const retry = makeQueryClient().getDefaultOptions().queries!.retry as (
+    n: number,
+    e: Error
+  ) => boolean;
+  expect(retry(0, new NetworkError("x"))).toBe(true);
+  expect(retry(0, new SchemaMismatchError("/products", "bad"))).toBe(false);
+  expect(retry(0, new HttpError(404))).toBe(false);
+  expect(retry(5, new NetworkError("x"))).toBe(false); // bounded
+});

--- a/apps/web/src/api/errors.ts
+++ b/apps/web/src/api/errors.ts
@@ -1,0 +1,26 @@
+// Three failures that need three different responses (spec §B3). Collapsing the third into a
+// generic error is how a contract violation gets mistaken for an empty catalogue.
+export class NetworkError extends Error {
+  constructor(cause: unknown) {
+    super("the gateway could not be reached");
+    this.name = "NetworkError";
+    this.cause = cause;
+  }
+}
+
+export class HttpError extends Error {
+  constructor(readonly status: number) {
+    super(`the gateway answered ${status}`);
+    this.name = "HttpError";
+  }
+}
+
+export class SchemaMismatchError extends Error {
+  constructor(
+    readonly path: string,
+    readonly detail: string
+  ) {
+    super(`response from ${path} did not match its contract: ${detail}`);
+    this.name = "SchemaMismatchError";
+  }
+}

--- a/apps/web/src/api/products.ts
+++ b/apps/web/src/api/products.ts
@@ -2,9 +2,15 @@ import { z } from "zod";
 import { ProductDetailSchema, ProductListItemSchema } from "@ecom/contracts";
 import { request } from "./request";
 
+// Every gateway call goes under /api, which the proxy strips. Rooted at /products these paths
+// would shadow the storefront's own /products/:id page — the proxy answers first, so a hard
+// refresh on a product returns JSON instead of the app.
+const API = "/api";
+
 // GET /products takes NO parameters — Catalog serves the whole catalogue in one response
 // (findMany with no take/skip). Sending ?limit= would imply a pagination that does not exist.
-export const listProducts = () => request("/products", z.array(ProductListItemSchema));
+export const listProducts = () =>
+  request(`${API}/products`, z.array(ProductListItemSchema));
 
 export const getProduct = (id: string) =>
-  request(`/products/${encodeURIComponent(id)}`, ProductDetailSchema);
+  request(`${API}/products/${encodeURIComponent(id)}`, ProductDetailSchema);

--- a/apps/web/src/api/products.ts
+++ b/apps/web/src/api/products.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+import { ProductDetailSchema, ProductListItemSchema } from "@ecom/contracts";
+import { request } from "./request";
+
+// GET /products takes NO parameters — Catalog serves the whole catalogue in one response
+// (findMany with no take/skip). Sending ?limit= would imply a pagination that does not exist.
+export const listProducts = () => request("/products", z.array(ProductListItemSchema));
+
+export const getProduct = (id: string) =>
+  request(`/products/${encodeURIComponent(id)}`, ProductDetailSchema);

--- a/apps/web/src/api/queryClient.ts
+++ b/apps/web/src/api/queryClient.ts
@@ -1,0 +1,15 @@
+import { QueryClient } from "@tanstack/react-query";
+import { NetworkError } from "./errors";
+
+// React Query retries 3x on EVERY error by default. Left alone that contradicts the error
+// taxonomy outright: a SchemaMismatchError is a bug that must surface at once, and a 404 is
+// for a product that will never exist. Retry network failures only.
+export const makeQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: (failureCount, error) => error instanceof NetworkError && failureCount < 2,
+        staleTime: 30_000,
+      },
+    },
+  });

--- a/apps/web/src/api/request.ts
+++ b/apps/web/src/api/request.ts
@@ -1,0 +1,27 @@
+import type { ZodType } from "zod";
+import { HttpError, NetworkError, SchemaMismatchError } from "./errors";
+
+// The only module that knows HTTP exists. Everything above it receives typed values or typed
+// errors. Paths are ALWAYS same-origin — Vite (dev) and nginx (prod) proxy them to the
+// gateway, so no absolute URL and no gateway host ever enters the bundle.
+export async function request<T>(path: string, schema: ZodType<T>): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(path, { headers: { accept: "application/json" } });
+  } catch (cause) {
+    throw new NetworkError(cause);
+  }
+
+  if (!res.ok) throw new HttpError(res.status);
+
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch (cause) {
+    throw new SchemaMismatchError(path, `body was not JSON (${String(cause)})`);
+  }
+
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) throw new SchemaMismatchError(path, parsed.error.message);
+  return parsed.data;
+}

--- a/apps/web/src/components/Badge.tsx
+++ b/apps/web/src/components/Badge.tsx
@@ -1,0 +1,7 @@
+export function Badge({ children }: { children: string }) {
+  return (
+    <span className="datum rounded-full border border-[color:var(--color-line-strong)] bg-[color:var(--color-surface)] px-2 py-0.5 text-[10.5px] uppercase tracking-[0.12em] text-[color:var(--color-muted)]">
+      {children}
+    </span>
+  );
+}

--- a/apps/web/src/components/Button.tsx
+++ b/apps/web/src/components/Button.tsx
@@ -1,0 +1,12 @@
+import type { ButtonHTMLAttributes } from "react";
+
+export function Button({ children, ...rest }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      {...rest}
+      className="inline-flex h-11 items-center justify-center rounded-md border border-[color:var(--color-ink)] bg-[color:var(--color-ink)] px-5 text-sm text-[color:var(--color-paper)]"
+    >
+      {children}
+    </button>
+  );
+}

--- a/apps/web/src/components/Card.tsx
+++ b/apps/web/src/components/Card.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export function Card({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex flex-col overflow-hidden rounded-lg border border-[color:var(--color-line)] bg-[color:var(--color-surface)] shadow-[var(--shadow-1)]">
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/components/EmptyState.tsx
+++ b/apps/web/src/components/EmptyState.tsx
@@ -1,0 +1,7 @@
+export function EmptyState({ message }: { message: string }) {
+  return (
+    <p className="rounded-md border border-dashed border-[color:var(--color-line-strong)] p-12 text-center text-[color:var(--color-muted)]">
+      {message}
+    </p>
+  );
+}

--- a/apps/web/src/components/ErrorState.tsx
+++ b/apps/web/src/components/ErrorState.tsx
@@ -1,0 +1,27 @@
+import { HttpError, NetworkError, SchemaMismatchError } from "../api/errors";
+import { Button } from "./Button";
+
+// A schema mismatch is backend drift, not a user condition — it says so plainly rather than
+// rendering as "something went wrong", which is how a contract violation gets mistaken for an
+// empty catalogue.
+export function ErrorState({ error, onRetry }: { error: unknown; onRetry?: () => void }) {
+  const message =
+    error instanceof NetworkError
+      ? "Could not reach the store. Check your connection."
+      : error instanceof SchemaMismatchError
+        ? "The store sent data this page does not understand. This is a bug, not you."
+        : error instanceof HttpError
+          ? `The store answered ${error.status}.`
+          : "Something went wrong.";
+
+  return (
+    <div role="alert" className="p-12 text-center">
+      <p className="text-[color:var(--color-muted)]">{message}</p>
+      {error instanceof NetworkError && onRetry ? (
+        <div className="mt-4">
+          <Button onClick={onRetry}>Try again</Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/Price.tsx
+++ b/apps/web/src/components/Price.tsx
@@ -1,0 +1,7 @@
+// price is integer MINOR UNITS everywhere in the system; this is the only place it becomes
+// a human number (Global Constraint 9).
+const fmt = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" });
+
+export function Price({ minorUnits }: { minorUnits: number }) {
+  return <span className="datum">{fmt.format(minorUnits / 100)}</span>;
+}

--- a/apps/web/src/components/ProductCard.tsx
+++ b/apps/web/src/components/ProductCard.tsx
@@ -1,0 +1,25 @@
+import { Link } from "react-router";
+import type { ProductListItem } from "@ecom/contracts";
+import { Badge } from "./Badge";
+import { Card } from "./Card";
+import { Price } from "./Price";
+import { Silhouette } from "./Silhouette";
+
+export function ProductCard({ product }: { product: ProductListItem }) {
+  return (
+    <Link to={`/products/${product.id}`}>
+      <Card>
+        <div className="relative flex aspect-[4/3] items-center justify-center bg-[color:var(--color-surface-2)]">
+          <div className="absolute left-3 top-3">
+            <Badge>{product.type}</Badge>
+          </div>
+          <Silhouette type={product.type} />
+        </div>
+        <div className="flex flex-col gap-1 p-4">
+          <span className="text-[15px] font-medium">{product.name}</span>
+          <Price minorUnits={product.price} />
+        </div>
+      </Card>
+    </Link>
+  );
+}

--- a/apps/web/src/components/Silhouette.tsx
+++ b/apps/web/src/components/Silhouette.tsx
@@ -1,0 +1,27 @@
+import type { ProductType } from "@ecom/contracts";
+
+const PATHS: Record<ProductType, string> = {
+  ELECTRONICS: "M8 8h48v30H8zM4 44h56M26 38v6M38 38v6",
+  CLOTHING: "M24 6l8 6 8-6 12 8-6 8-6-3v18H24V19l-6 3-6-8z",
+  FURNITURE: "M14 24V12a6 6 0 016-6h24a6 6 0 016 6v12M10 24h44v10H10zM14 34v8M50 34v8",
+  MOTORBIKE: "M15 34l10-16h16l6 8M25 18l-4-6h10M41 18l16 16M31 34h20",
+};
+const FALLBACK = "M10 10h44v28H10z";
+
+export function Silhouette({ type }: { type: ProductType }) {
+  const d = PATHS[type] ?? FALLBACK;
+  return (
+    <svg
+      viewBox="0 0 64 48"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className="w-1/2 text-[color:var(--color-ink-soft)]"
+    >
+      <path d={d} />
+    </svg>
+  );
+}

--- a/apps/web/src/components/Skeleton.tsx
+++ b/apps/web/src/components/Skeleton.tsx
@@ -1,0 +1,10 @@
+// Matches the card geometry rather than being a spinner, so the grid does not reflow when
+// data lands.
+export function Skeleton() {
+  return (
+    <div
+      data-testid="skeleton"
+      className="h-64 animate-pulse rounded-lg bg-[color:var(--color-surface-2)]"
+    />
+  );
+}

--- a/apps/web/src/components/__tests__/Price.test.tsx
+++ b/apps/web/src/components/__tests__/Price.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from "@testing-library/react";
+import { Price } from "../Price";
+
+it.each([
+  [900, "$9.00"],
+  [2450, "$24.50"],
+  [890000, "$8,900.00"],
+  [0, "$0.00"],
+])("renders %i minor units as %s", (minor, expected) => {
+  render(<Price minorUnits={minor} />);
+  expect(screen.getByText(expected)).toBeInTheDocument();
+});

--- a/apps/web/src/components/__tests__/Silhouette.test.tsx
+++ b/apps/web/src/components/__tests__/Silhouette.test.tsx
@@ -1,0 +1,19 @@
+import { render } from "@testing-library/react";
+import { Silhouette } from "../Silhouette";
+
+it.each(["ELECTRONICS", "CLOTHING", "FURNITURE", "MOTORBIKE"] as const)(
+  "renders a shape for %s",
+  (type) => {
+    const { container } = render(<Silhouette type={type} />);
+    expect(container.querySelector("svg")).not.toBeNull();
+  }
+);
+
+// Degrade, never crash: the union comes from a network response, so an unknown value is
+// reachable if Catalog ever adds a type before the storefront knows about it.
+it("degrades to a neutral shape for an unknown type", () => {
+  const { container } = render(
+    <Silhouette type={"SPACESHIP" as unknown as "ELECTRONICS"} />
+  );
+  expect(container.querySelector("svg")).not.toBeNull();
+});

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+import "./styles.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,10 +1,14 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { App } from "./App";
+import { makeQueryClient } from "./api/queryClient";
 import "./styles.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={makeQueryClient()}>
+      <App />
+    </QueryClientProvider>
   </StrictMode>
 );

--- a/apps/web/src/routes/Home.tsx
+++ b/apps/web/src/routes/Home.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import type { ProductType } from "@ecom/contracts";
+import { listProducts } from "../api/products";
+import { EmptyState } from "../components/EmptyState";
+import { ErrorState } from "../components/ErrorState";
+import { ProductCard } from "../components/ProductCard";
+import { Skeleton } from "../components/Skeleton";
+
+const CATEGORIES: (ProductType | "ALL")[] = [
+  "ALL",
+  "MOTORBIKE",
+  "ELECTRONICS",
+  "FURNITURE",
+  "CLOTHING",
+];
+
+export function Home() {
+  const [filter, setFilter] = useState<ProductType | "ALL">("ALL");
+  const { data, error, isPending, refetch } = useQuery({
+    queryKey: ["products"],
+    queryFn: listProducts,
+  });
+
+  if (isPending) {
+    return (
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+        {Array.from({ length: 8 }, (_, i) => (
+          <Skeleton key={i} />
+        ))}
+      </div>
+    );
+  }
+  if (error) return <ErrorState error={error} onRetry={() => void refetch()} />;
+
+  const shown = filter === "ALL" ? data : data.filter((p) => p.type === filter);
+
+  return (
+    <>
+      <div className="mb-4 flex flex-wrap gap-2">
+        {CATEGORIES.map((c) => (
+          <button
+            key={c}
+            onClick={() => setFilter(c)}
+            aria-pressed={filter === c}
+            className="datum rounded-full border border-[color:var(--color-line)] px-3 py-1.5 text-xs uppercase"
+          >
+            {c}
+          </button>
+        ))}
+      </div>
+      {shown.length === 0 ? (
+        <EmptyState message="No products in the catalogue yet." />
+      ) : (
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+          {shown.map((p) => (
+            <ProductCard key={p.id} product={p} />
+          ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/routes/Product.tsx
+++ b/apps/web/src/routes/Product.tsx
@@ -1,0 +1,69 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link, useParams } from "react-router";
+import { HttpError } from "../api/errors";
+import { getProduct } from "../api/products";
+import { Badge } from "../components/Badge";
+import { ErrorState } from "../components/ErrorState";
+import { Price } from "../components/Price";
+import { Silhouette } from "../components/Silhouette";
+import { Skeleton } from "../components/Skeleton";
+
+// attributes values are `unknown` by contract. Render primitives; skip everything else rather
+// than emitting "[object Object]". Values are API-sourced strings, so they go through React's
+// normal escaping — never dangerouslySetInnerHTML.
+function primitiveEntries(attributes: Record<string, unknown>) {
+  return Object.entries(attributes).filter(
+    ([, v]) => typeof v === "string" || typeof v === "number" || typeof v === "boolean"
+  ) as [string, string | number | boolean][];
+}
+
+export function Product() {
+  const { id = "" } = useParams();
+  const { data, error, isPending, refetch } = useQuery({
+    queryKey: ["product", id],
+    queryFn: () => getProduct(id),
+  });
+
+  if (isPending) return <Skeleton />;
+
+  if (error instanceof HttpError && error.status === 404) {
+    return (
+      <div className="p-12 text-center">
+        <h1 className="text-2xl">Product not found</h1>
+        <p className="mt-2 text-[color:var(--color-muted)]">
+          It may have been removed since you last looked.
+        </p>
+        <Link to="/" className="datum mt-4 inline-block underline">
+          Back to the catalogue
+        </Link>
+      </div>
+    );
+  }
+  if (error) return <ErrorState error={error} onRetry={() => void refetch()} />;
+
+  return (
+    <div className="grid gap-8 md:grid-cols-2">
+      <div className="flex aspect-[4/3] items-center justify-center rounded-lg border border-[color:var(--color-line)] bg-[color:var(--color-surface-2)]">
+        <Silhouette type={data.type} />
+      </div>
+      <div className="flex flex-col gap-4">
+        <Badge>{data.type}</Badge>
+        <h1 className="text-3xl">{data.name}</h1>
+        <Price minorUnits={data.price} />
+        <dl className="border-t border-[color:var(--color-line)]">
+          {primitiveEntries(data.attributes).map(([k, v]) => (
+            <div
+              key={k}
+              className="flex justify-between border-b border-[color:var(--color-line)] py-2"
+            >
+              <dt className="datum text-xs uppercase text-[color:var(--color-muted)]">
+                {k}
+              </dt>
+              <dd className="datum">{String(v)}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/__tests__/Home.test.tsx
+++ b/apps/web/src/routes/__tests__/Home.test.tsx
@@ -1,0 +1,73 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { makeQueryClient } from "../../api/queryClient";
+import { HttpError } from "../../api/errors";
+import * as api from "../../api/products";
+import { Home } from "../Home";
+
+// MemoryRouter is not optional scaffolding: every ProductCard is a <Link>, which reads the
+// router context directly and throws when it is null. Without it the two tests that render
+// cards fail on a router error rather than on anything they are asserting.
+function renderHome() {
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={makeQueryClient()}>
+        <Home />
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+const product = (over = {}) => ({
+  id: "p1",
+  type: "ELECTRONICS" as const,
+  name: "Widget",
+  price: 900,
+  version: 1,
+  ...over,
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+it("shows skeletons while loading", () => {
+  vi.spyOn(api, "listProducts").mockReturnValue(new Promise(() => {}));
+  renderHome();
+  expect(screen.getAllByTestId("skeleton").length).toBeGreaterThan(0);
+});
+
+it("renders a card per product once loaded", async () => {
+  vi.spyOn(api, "listProducts").mockResolvedValue([
+    product(),
+    product({ id: "p2", name: "Shirt", type: "CLOTHING", price: 2450 }),
+  ]);
+  renderHome();
+  expect(await screen.findByText("Widget")).toBeInTheDocument();
+  expect(screen.getByText("Shirt")).toBeInTheDocument();
+  expect(screen.getByText("$9.00")).toBeInTheDocument();
+});
+
+it("shows the empty state for an empty catalogue", async () => {
+  vi.spyOn(api, "listProducts").mockResolvedValue([]);
+  renderHome();
+  expect(await screen.findByText(/no products/i)).toBeInTheDocument();
+});
+
+it("shows the error state when the gateway errors", async () => {
+  vi.spyOn(api, "listProducts").mockRejectedValue(new HttpError(500));
+  renderHome();
+  expect(await screen.findByRole("alert")).toHaveTextContent("500");
+});
+
+it("filters by category", async () => {
+  vi.spyOn(api, "listProducts").mockResolvedValue([
+    product(),
+    product({ id: "p2", name: "Shirt", type: "CLOTHING" }),
+  ]);
+  renderHome();
+  expect(await screen.findByText("Widget")).toBeInTheDocument();
+  // fireEvent, not node.click(): a raw DOM click is not wrapped in act(), so the state
+  // update would not be flushed before the assertions below.
+  fireEvent.click(screen.getByRole("button", { name: /clothing/i }));
+  expect(screen.queryByText("Widget")).not.toBeInTheDocument();
+  expect(screen.getByText("Shirt")).toBeInTheDocument();
+});

--- a/apps/web/src/routes/__tests__/Product.test.tsx
+++ b/apps/web/src/routes/__tests__/Product.test.tsx
@@ -1,0 +1,64 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { makeQueryClient } from "../../api/queryClient";
+import { HttpError } from "../../api/errors";
+import * as api from "../../api/products";
+import { Product } from "../Product";
+
+function renderAt(id: string) {
+  const router = createMemoryRouter([{ path: "/products/:id", element: <Product /> }], {
+    initialEntries: [`/products/${id}`],
+  });
+  return render(
+    <QueryClientProvider client={makeQueryClient()}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  );
+}
+const detail = (over = {}) => ({
+  id: "p1",
+  type: "ELECTRONICS" as const,
+  name: "Widget",
+  price: 900,
+  version: 3,
+  attributes: { manufacturer: "Acme" },
+  ...over,
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+it("renders name, price and the attributes table", async () => {
+  vi.spyOn(api, "getProduct").mockResolvedValue(detail());
+  renderAt("p1");
+  expect(await screen.findByText("Widget")).toBeInTheDocument();
+  expect(screen.getByText("$9.00")).toBeInTheDocument();
+  expect(screen.getByText("manufacturer")).toBeInTheDocument();
+  expect(screen.getByText("Acme")).toBeInTheDocument();
+});
+
+// Reachable with nothing broken: a stale link, or a product removed between list and click.
+it("renders a not-found view on 404, not a generic error", async () => {
+  vi.spyOn(api, "getProduct").mockRejectedValue(new HttpError(404));
+  renderAt("gone");
+  expect(await screen.findByText(/not found/i)).toBeInTheDocument();
+  expect(screen.getByRole("link", { name: /catalogue/i })).toBeInTheDocument();
+});
+
+it("still shows the error state for a non-404", async () => {
+  vi.spyOn(api, "getProduct").mockRejectedValue(new HttpError(500));
+  renderAt("p1");
+  expect(await screen.findByRole("alert")).toHaveTextContent("500");
+});
+
+// attributes is z.record(z.unknown()) — values are genuinely unknown at compile time.
+it("renders primitive attributes and skips non-primitive ones", async () => {
+  vi.spyOn(api, "getProduct").mockResolvedValue(
+    detail({ attributes: { brand: "Acme", sizes: { eu: 42 }, inStock: true } })
+  );
+  renderAt("p1");
+  expect(await screen.findByText("brand")).toBeInTheDocument();
+  expect(screen.getByText("true")).toBeInTheDocument();
+  expect(screen.queryByText("sizes")).not.toBeInTheDocument();
+  expect(screen.queryByText(/object Object/)).not.toBeInTheDocument();
+});

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,1 +1,81 @@
 @import "tailwindcss";
+
+/* `static` emits every variable declared here, not only the ones a generated utility
+   happens to reference. Without it Tailwind tree-shakes the block down to whatever the
+   `body` rule touches, and the arbitrary-value classes below — text-[color:var(--color-muted)]
+   and friends — resolve against variables that were never emitted. */
+@theme static {
+  --color-paper: #f1f1f4;
+  --color-surface: #ffffff;
+  --color-surface-2: #f4f4f7;
+  --color-ink: #1d1d1f;
+  --color-ink-soft: #3c3c42;
+  --color-muted: #6e6e76;
+  --color-line: #e8e8ed;
+  --color-line-strong: #dcdce3;
+
+  /* Reserved to encode saga state — unused in 8a on purpose (spec §D). */
+  --color-live: #b26a12;
+  --color-live-bg: #fbf0de;
+  --color-ok: #2e7d46;
+  --color-ok-bg: #e4f1e8;
+  --color-fail: #c0392b;
+  --color-fail-bg: #fbe6e3;
+  --color-focus: #2f73e8;
+
+  --radius-sm: 12px;
+  /* `md`, not `DEFAULT`: Tailwind v4 dropped the -DEFAULT convention, and its bare `rounded`
+     utility is a static 0.25rem that reads no variable at all. Named DEFAULT this token would
+     be emitted, referenced by nothing, and every `rounded` element would silently render at
+     4px beside 24px cards. */
+  --radius-md: 16px;
+  --radius-lg: 24px;
+
+  --shadow-1: 0 1px 2px rgba(20, 20, 30, 0.05), 0 6px 18px rgba(20, 20, 30, 0.06);
+  --shadow-2: 0 4px 12px rgba(20, 20, 30, 0.08), 0 24px 52px rgba(20, 20, 30, 0.12);
+
+  --font-sans:
+    -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", Roboto, Helvetica,
+    Arial, sans-serif;
+  --font-mono:
+    ui-monospace, "SF Mono", "Cascadia Code", "JetBrains Mono", Menlo, Consolas, monospace;
+}
+
+/* Dark values ship now; the toggle is 8c. Media query only.
+
+   These override `:root` directly rather than nesting a second `@theme`. Tailwind v4 hoists
+   `@theme` to the top level unconditionally — nested in a media query it does not become
+   conditional, it becomes an unconditional overwrite, and the light palette disappears from
+   the bundle entirely. Overriding the variables `@theme` already emitted is the supported
+   way to make them conditional. */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-paper: #0c0c0f;
+    --color-surface: #191a1e;
+    --color-surface-2: #232429;
+    --color-ink: #f2f2f4;
+    --color-ink-soft: #c9cacd;
+    --color-muted: #909198;
+    --color-line: #2a2b31;
+    --color-line-strong: #3a3b42;
+    --color-live: #e4aa53;
+    --color-live-bg: #2c2616;
+    --color-ok: #5fbe7c;
+    --color-ok-bg: #14251a;
+    --color-fail: #e8776a;
+    --color-fail-bg: #2c1917;
+    --color-focus: #5c93f2;
+  }
+}
+
+body {
+  background: var(--color-paper);
+  color: var(--color-ink);
+  font-family: var(--font-sans);
+}
+
+/* Every datum — prices, ids, versions — is mono with tabular figures (spec §D). */
+.datum {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    // `globals: true` in vitest.config.ts means vi/it/expect are ambient — without
+    // "vitest/globals" here every test file fails `pnpm typecheck` on unresolved names.
+    "types": ["vite/client", "vitest/globals"]
+  },
+  "include": ["src", "vite.config.ts", "vitest.config.ts", "vitest.setup.ts"]
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+
+// The browser never addresses the gateway directly. Every API prefix is proxied so the app
+// is same-origin: no CORS on the gateway, and 8b's cookies work on SameSite=Lax.
+const GATEWAY = process.env.GATEWAY_URL ?? "http://localhost:8000";
+const API_PREFIXES = ["/products", "/cart", "/orders", "/auth"];
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  server: {
+    proxy: Object.fromEntries(
+      API_PREFIXES.map((p) => [p, { target: GATEWAY, changeOrigin: true }])
+    ),
+  },
+});

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -2,16 +2,27 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
-// The browser never addresses the gateway directly. Every API prefix is proxied so the app
-// is same-origin: no CORS on the gateway, and 8b's cookies work on SameSite=Lax.
+// The browser never addresses the gateway directly. The API is proxied so the app is
+// same-origin: no CORS on the gateway, and 8b's cookies work on SameSite=Lax.
+//
+// Everything the gateway serves sits under one /api prefix, stripped on the way through,
+// rather than proxying the gateway's own prefixes at the origin root. Rooted, /products would
+// be both an API resource and this app's product page — and the proxy wins, so a hard refresh
+// or a shared link to a product renders raw JSON instead of the app. 8b makes that worse:
+// /cart and /orders are storefront pages too. One namespace keeps the two URL spaces disjoint
+// by construction, and 8c's nginx needs one location block instead of a rule per prefix.
 const GATEWAY = process.env.GATEWAY_URL ?? "http://localhost:8000";
-const API_PREFIXES = ["/products", "/cart", "/orders", "/auth"];
+const API_PREFIX = "/api";
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
-    proxy: Object.fromEntries(
-      API_PREFIXES.map((p) => [p, { target: GATEWAY, changeOrigin: true }])
-    ),
+    proxy: {
+      [API_PREFIX]: {
+        target: GATEWAY,
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ""),
+      },
+    },
   },
 });

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,15 @@
+// The test config is deliberately separate from vite.config.ts. Vitest 2.1 (the repo pin)
+// carries vite 5 types while this app builds on vite 8, so a single config holding both the
+// vite-8 plugin array and the `test` block cannot typecheck against either signature. Keeping
+// `test` here — with no plugins — also stops vitest's vite 5 from loading vite 8 plugins.
+// JSX still transforms: esbuild reads `jsx: "react-jsx"` from tsconfig.json.
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./vitest.setup.ts"],
+    include: ["src/**/*.test.{ts,tsx}"],
+  },
+});

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/docs/superpowers/plans/2026-07-30-phase-8a-storefront-foundation.md
+++ b/docs/superpowers/plans/2026-07-30-phase-8a-storefront-foundation.md
@@ -1,0 +1,1558 @@
+# Phase 8a — Storefront foundation + catalogue — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up `apps/web` — a Vite + React storefront in the pnpm workspace — rendering
+Catalog's product list and detail through the gateway, with every response validated at the
+boundary against schemas that Catalog itself is tested against.
+
+**Architecture:** The app joins the existing workspace and imports `@ecom/contracts` as
+TypeScript source, exactly as the eight services do. The browser never addresses the gateway
+directly: Vite's dev server proxies the API prefixes, so there is no CORS and no gateway URL
+in the bundle. One `request()` helper owns fetch, status mapping and zod parsing, and is the
+only code that knows HTTP exists. Design tokens are declared once in a Tailwind v4 `@theme`
+block lifted from the approved prototype.
+
+**Tech Stack:** React 19.2, Vite 8.2, Tailwind CSS 4.3 (CSS-first, `@tailwindcss/vite`),
+React Router 8.3, TanStack Query 5.101, Vitest 2.1 (the repo's existing pin) + Testing
+Library 16.3 + jsdom 30, TypeScript 5.7 (the repo's existing pin), zod 3 via
+`@ecom/contracts`.
+
+Spec: `docs/superpowers/specs/2026-07-30-phase-8a-storefront-foundation-design.md`.
+
+## Global Constraints
+
+Every task's requirements implicitly include this section.
+
+1. **Base branch must contain Phase 7d.** Per the spec's §Preconditions, start from `main`
+   once PR #7 merges (preferred), or from 7d's head. Do **not** implement on a base without
+   it: 7d added the `infra/**` glob to `vitest.config.ts` and a `k6/**` block to
+   `eslint.config.js`, and both files are edited here.
+2. **`vitest.workspace.ts` must carry an `infra` project**, alongside `packages`, `services`
+   and the new `apps/web`. Dropping it re-creates the uncovered-suite gap 7d closed.
+3. **Vitest stays at the repo's `^2.1.0` and TypeScript at `^5.7.0`.** Vitest 4 removed
+   `vitest.workspace.ts` and TypeScript 7 is a rewrite; upgrading either would touch every
+   service's tests and is out of scope for a frontend slice.
+4. **No production code in any of the eight services changes.** The only service file touched
+   is a new Catalog *test* file (Task 2).
+5. **Exact pinned versions** (resolved 2026-07-30 — the spec requires pinning rather than
+   trusting peer-support claims):
+   `react@19.2.8`, `react-dom@19.2.8`, `vite@8.2.0`, `@vitejs/plugin-react@6.0.5`,
+   `tailwindcss@4.3.3`, `@tailwindcss/vite@4.3.3`, `react-router@8.3.0`,
+   `@tanstack/react-query@5.101.4`, `jsdom@30.0.1`, `@testing-library/react@16.3.2`,
+   `@testing-library/jest-dom@7.0.0`.
+6. **Tailwind v4 is CSS-first.** Tokens live in an `@theme` block in CSS. There is no
+   `tailwind.config.js` and no `content` array — do not create one.
+7. **No hard-coded colour, radius or shadow literal in any component.** Every one comes from
+   a token (spec §H).
+8. **No API-sourced value is ever passed to `dangerouslySetInnerHTML`** (spec §C3).
+9. **`price` is integer minor units.** Divide by 100 at the presentation layer only.
+10. **The browser only ever calls same-origin paths.** No absolute gateway URL in any
+    component, and no CORS middleware is added to the gateway.
+
+---
+
+## File Structure
+
+**Created**
+
+| File | Responsibility |
+|---|---|
+| `apps/web/package.json` | Workspace member; scripts `dev`/`build`/`typecheck`/`lint` |
+| `apps/web/index.html` | Vite entry document |
+| `apps/web/vite.config.ts` | React + Tailwind plugins, dev proxy for API prefixes |
+| `apps/web/tsconfig.json` | Extends the repo base; DOM libs, JSX |
+| `apps/web/vitest.setup.ts` | Registers `@testing-library/jest-dom` |
+| `apps/web/src/main.tsx` | Mounts React, QueryClientProvider, RouterProvider |
+| `apps/web/src/styles.css` | `@import "tailwindcss"` + the `@theme` token block |
+| `apps/web/src/api/errors.ts` | `NetworkError`, `HttpError`, `SchemaMismatchError` |
+| `apps/web/src/api/request.ts` | fetch → status mapping → zod parse. Only HTTP-aware module |
+| `apps/web/src/api/products.ts` | `listProducts()`, `getProduct(id)` |
+| `apps/web/src/api/queryClient.ts` | Retry policy pinned to network-only |
+| `apps/web/src/components/*.tsx` | `Card`, `Badge`, `Price`, `Skeleton`, `EmptyState`, `ErrorState`, `Button`, `Silhouette` |
+| `apps/web/src/routes/Home.tsx` | Hero, category chips, product grid, 3 async states |
+| `apps/web/src/routes/Product.tsx` | Detail, attributes table, 404 case |
+| `packages/contracts/src/http/catalog.ts` | `ProductListItem`, `ProductDetail` schemas |
+| `services/catalog/src/__tests__/product-contract.int.test.ts` | Catalog asserts its own responses satisfy the shared schemas |
+| `vitest.workspace.ts` | Four projects; existing three unchanged |
+
+**Modified**
+
+| File | Change |
+|---|---|
+| `pnpm-workspace.yaml` | Add `apps/*` |
+| `eslint.config.js` | Add an `apps/web/**` block (JSX + react-hooks) |
+| `packages/contracts/src/index.ts` | Export the new HTTP schemas |
+| `docs/superpowers/specs/2026-07-18-microservices-streaming-rebuild-design.md` | Two DoD amendments (Task 7) |
+| `docs/superpowers/specs/2026-07-23-phases-3-8-roadmap.md` | 8a line amendment (Task 7) |
+
+---
+
+### Task 1: Workspace member, vitest project, lint block
+
+Scaffolding, config and the test wiring all serve one deliverable — an `apps/web` that the
+repo's existing recursive scripts pick up — so they are one task.
+
+**Files:**
+- Create: `apps/web/package.json`, `apps/web/index.html`, `apps/web/vite.config.ts`,
+  `apps/web/tsconfig.json`, `apps/web/vitest.setup.ts`, `apps/web/src/main.tsx`,
+  `apps/web/src/App.tsx`, `apps/web/src/styles.css`
+- Create: `vitest.workspace.ts`
+- Create: `apps/web/src/__tests__/smoke.test.tsx`
+- Modify: `pnpm-workspace.yaml`, `eslint.config.js`
+
+**Interfaces:**
+- Produces: the `@ecom/web` workspace package; a `apps/web` vitest project running in jsdom.
+
+- [ ] **Step 1: Add `apps/*` to the workspace**
+
+In `pnpm-workspace.yaml`, add `- "apps/*"` under the existing `packages:` list, keeping the
+`onlyBuiltDependencies` block untouched:
+
+```yaml
+packages:
+  - "packages/*"
+  - "services/*"
+  - "apps/*"
+```
+
+- [ ] **Step 2: Create the package manifest**
+
+`apps/web/package.json`:
+
+```json
+{
+  "name": "@ecom/web",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -p tsconfig.json --noEmit && vite build",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@ecom/contracts": "workspace:*",
+    "@tanstack/react-query": "5.101.4",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
+    "react-router": "8.3.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "4.3.3",
+    "@testing-library/jest-dom": "7.0.0",
+    "@testing-library/react": "16.3.2",
+    "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.0",
+    "@vitejs/plugin-react": "6.0.5",
+    "jsdom": "30.0.1",
+    "tailwindcss": "4.3.3",
+    "vite": "8.2.0"
+  }
+}
+```
+
+Note there is no `vitest` dependency here — the root's `^2.1.0` runs every project.
+
+- [ ] **Step 3: Create tsconfig**
+
+`apps/web/tsconfig.json`:
+
+```json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    // `globals: true` in vite.config.ts means vi/it/expect are ambient — without
+    // "vitest/globals" here every test file fails `pnpm typecheck` on unresolved names.
+    "types": ["vite/client", "vitest/globals"]
+  },
+  "include": ["src", "vite.config.ts", "vitest.setup.ts"]
+}
+```
+
+`module`/`moduleResolution` are overridden because the repo base targets CommonJS for Node
+services; Vite needs ESM + bundler resolution.
+
+- [ ] **Step 4: Create the Vite config with the dev proxy**
+
+`apps/web/vite.config.ts`. The proxy is what makes the browser same-origin (spec §C1):
+
+```ts
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+
+// The browser never addresses the gateway directly. Every API prefix is proxied so the app
+// is same-origin: no CORS on the gateway, and 8b's cookies work on SameSite=Lax.
+const GATEWAY = process.env.GATEWAY_URL ?? "http://localhost:8000";
+const API_PREFIXES = ["/products", "/cart", "/orders", "/auth"];
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  server: {
+    proxy: Object.fromEntries(
+      API_PREFIXES.map((p) => [p, { target: GATEWAY, changeOrigin: true }])
+    ),
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./vitest.setup.ts"],
+    include: ["src/**/*.test.{ts,tsx}"],
+  },
+});
+```
+
+- [ ] **Step 5: Create the vitest setup file**
+
+`apps/web/vitest.setup.ts`:
+
+```ts
+import "@testing-library/jest-dom/vitest";
+```
+
+- [ ] **Step 6: Create the workspace test config**
+
+`vitest.workspace.ts` at the repo root. **Global Constraint 2**: the `infra` project must be
+here.
+
+```ts
+// One `pnpm vitest run` covers every project. The three node projects keep the globs and
+// timeouts the root config already used; apps/web needs jsdom, which the node projects must
+// not inherit — which is the whole reason this file exists.
+import { defineWorkspace } from "vitest/config";
+
+const node = {
+  testTimeout: 20_000,
+  hookTimeout: 30_000,
+};
+
+export default defineWorkspace([
+  { test: { ...node, name: "packages", include: ["packages/**/*.test.ts"] } },
+  { test: { ...node, name: "services", include: ["services/**/*.test.ts"] } },
+  { test: { ...node, name: "infra", include: ["infra/**/*.test.ts"] } },
+  "./apps/web",
+]);
+```
+
+- [ ] **Step 7: Delete the superseded root config**
+
+Remove `vitest.config.ts`. Its three globs and both timeouts are carried above; leaving both
+files means vitest picks the workspace file and the stale one silently rots.
+
+```bash
+git rm vitest.config.ts
+```
+
+- [ ] **Step 8: Add the eslint block**
+
+In `eslint.config.js`, append a block after the existing `k6/**/*.js` block, before the
+closing `)`:
+
+```js
+  {
+    // The storefront runs in a browser with JSX, neither of which the service configs cover.
+    files: ["apps/web/**/*.{ts,tsx}"],
+    languageOptions: {
+      parserOptions: { ecmaFeatures: { jsx: true } },
+      globals: { window: "readonly", document: "readonly", fetch: "readonly" },
+    },
+  }
+```
+
+- [ ] **Step 9: Create the minimal app**
+
+`apps/web/src/styles.css`:
+
+```css
+@import "tailwindcss";
+```
+
+`apps/web/src/App.tsx`:
+
+```tsx
+export function App() {
+  return <h1>Storefront</h1>;
+}
+```
+
+`apps/web/index.html`:
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Storefront</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+```
+
+`apps/web/src/main.tsx`:
+
+```tsx
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+import "./styles.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);
+```
+
+- [ ] **Step 10: Write the failing smoke test**
+
+`apps/web/src/__tests__/smoke.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { App } from "../App";
+
+it("renders the app shell", () => {
+  render(<App />);
+  expect(screen.getByRole("heading", { name: "Storefront" })).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 11: Install and run — verify the new project is picked up**
+
+```bash
+pnpm install
+pnpm vitest run
+```
+
+Expected: four projects run. The `apps/web` project reports 1 passed. **If `apps/web` does
+not appear in the output, the workspace file is wrong — stop and fix it**, because a silently
+skipped project is exactly the failure this file exists to prevent.
+
+- [ ] **Step 12: Verify the recursive root scripts pick the app up**
+
+```bash
+pnpm typecheck && pnpm lint && pnpm format:check && pnpm -r build
+```
+
+Expected: all green, and `pnpm -r build` produces `apps/web/dist`.
+
+- [ ] **Step 13: Prove the contracts import resolves through Vite**
+
+This is the spec §A1 residual risk — verify it now, before any feature depends on it. Add to
+`apps/web/src/App.tsx` temporarily:
+
+```tsx
+import { ORDER_PLACED } from "@ecom/contracts";
+export function App() {
+  return <h1>Storefront {ORDER_PLACED}</h1>;
+}
+```
+
+Run `pnpm --filter @ecom/web build`. Expected: builds clean. If Vite fails to resolve or
+transform the TypeScript source, add to `vite.config.ts`:
+`optimizeDeps: { exclude: ["@ecom/contracts"] }`, and record it as a deviation. Then revert
+`App.tsx` to the version in Step 9 and re-run the smoke test.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add pnpm-workspace.yaml eslint.config.js vitest.workspace.ts apps/web
+git rm --cached vitest.config.ts 2>/dev/null || true
+git commit -m "feat(web): apps/web joins the workspace with its own vitest project"
+```
+
+---
+
+### Task 2: Read DTOs in contracts, pinned from both ends
+
+**Files:**
+- Create: `packages/contracts/src/http/catalog.ts`
+- Modify: `packages/contracts/src/index.ts`
+- Create: `services/catalog/src/__tests__/product-contract.int.test.ts`
+
+**Interfaces:**
+- Produces: `ProductListItemSchema`, `ProductDetailSchema`, and the inferred types
+  `ProductListItem`, `ProductDetail`, exported from `@ecom/contracts`.
+
+- [ ] **Step 1: Write the failing contract test**
+
+A new file rather than edits to `product.int.test.ts`, because contract conformance is a
+different concern from CRUD behaviour. It follows the repo's fixture-cleanup convention
+(tag what you seed, delete it by DB query in `afterAll`).
+
+`services/catalog/src/__tests__/product-contract.int.test.ts`:
+
+```ts
+import { describe, it, expect, afterAll } from "vitest";
+import request from "supertest";
+import { createApp } from "../app";
+import { prisma } from "../db";
+import { ProductListItemSchema, ProductDetailSchema } from "@ecom/contracts";
+
+const app = createApp();
+
+// Catalog asserting its OWN responses against the shared schemas is what makes the storefront
+// safe. A client that only validates on its side discovers drift at runtime, in a browser, as
+// a blank grid. Here, drift fails a backend test next to the change that caused it.
+const TEST_TAG = "test-catalog-contract-int";
+
+describe("catalog read API satisfies the shared contracts", () => {
+  afterAll(async () => {
+    const seeded = await prisma.product.findMany({
+      where: { name: { startsWith: TEST_TAG } },
+      select: { id: true },
+    });
+    const ids = seeded.map((p) => p.id);
+    if (ids.length > 0) {
+      await prisma.outbox.deleteMany({ where: { aggregateId: { in: ids } } });
+      await prisma.product.deleteMany({ where: { id: { in: ids } } });
+    }
+    await prisma.$disconnect();
+  });
+
+  it("GET /products items satisfy ProductListItemSchema", async () => {
+    await request(app)
+      .post("/products")
+      .send({
+        type: "ELECTRONICS",
+        name: `${TEST_TAG}-list`,
+        price: 900,
+        attributes: { manufacturer: "Acme" },
+      })
+      .expect(201);
+
+    const res = await request(app).get("/products").expect(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThan(0);
+    for (const item of res.body) {
+      const parsed = ProductListItemSchema.safeParse(item);
+      if (!parsed.success) throw new Error(`list item drifted: ${parsed.error.message}`);
+    }
+  });
+
+  it("GET /products/:id satisfies ProductDetailSchema, including attributes", async () => {
+    const created = await request(app)
+      .post("/products")
+      .send({
+        type: "CLOTHING",
+        name: `${TEST_TAG}-detail`,
+        price: 2450,
+        attributes: { brand: "Acme", size: "M", material: "cotton", color: "blue" },
+      })
+      .expect(201);
+
+    const res = await request(app).get(`/products/${created.body.productId}`).expect(200);
+    const parsed = ProductDetailSchema.safeParse(res.body);
+    if (!parsed.success) throw new Error(`detail drifted: ${parsed.error.message}`);
+    expect(parsed.data.attributes).toMatchObject({ brand: "Acme" });
+    expect(parsed.data.price).toBe(2450);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `DATABASE_URL=postgresql://ecom:ecom@localhost:5432/catalog pnpm vitest run services/catalog/src/__tests__/product-contract.int.test.ts`
+Expected: FAIL — `ProductListItemSchema` is not exported from `@ecom/contracts`.
+
+- [ ] **Step 3: Write the schemas**
+
+`packages/contracts/src/http/catalog.ts`:
+
+```ts
+import { z } from "zod";
+
+// The READ API the storefront consumes, distinct from the event payloads in ../events/catalog.
+// Two schemas because the two routes genuinely differ: the list omits `attributes`. Modelling
+// that as one schema with an optional field would let a detail view silently render nothing
+// when the field goes missing.
+export const ProductTypeSchema = z.enum([
+  "ELECTRONICS",
+  "CLOTHING",
+  "FURNITURE",
+  "MOTORBIKE",
+]);
+export type ProductType = z.infer<typeof ProductTypeSchema>;
+
+export const ProductListItemSchema = z.object({
+  id: z.string(),
+  type: ProductTypeSchema,
+  name: z.string(),
+  // Integer MINOR UNITS. 900 is $9.00. Divide by 100 at the presentation layer only.
+  price: z.number().int(),
+  version: z.number().int(),
+});
+export type ProductListItem = z.infer<typeof ProductListItemSchema>;
+
+// `attributes` stays an open record: Catalog owns per-type attribute validation
+// (services/catalog/src/attributes.ts), and restating it here would create a second source of
+// truth to keep in sync — the exact drift these schemas exist to prevent.
+export const ProductDetailSchema = ProductListItemSchema.extend({
+  attributes: z.record(z.unknown()),
+});
+export type ProductDetail = z.infer<typeof ProductDetailSchema>;
+```
+
+- [ ] **Step 4: Export them**
+
+Add to `packages/contracts/src/index.ts`:
+
+```ts
+export * from "./http/catalog";
+```
+
+- [ ] **Step 5: Run and confirm green**
+
+Run: `DATABASE_URL=postgresql://ecom:ecom@localhost:5432/catalog pnpm vitest run services/catalog/src/__tests__/product-contract.int.test.ts`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 6: Prove the test discriminates**
+
+The whole value is that drift fails here. Temporarily change `price` in
+`ProductListItemSchema` to `z.string()`, re-run, and confirm **both** tests fail with a
+message naming `price`. Restore byte-identical and re-run to confirm green.
+
+- [ ] **Step 7: Typecheck and commit**
+
+```bash
+pnpm typecheck
+git add packages/contracts/src/http/catalog.ts packages/contracts/src/index.ts services/catalog/src/__tests__/product-contract.int.test.ts
+git commit -m "feat(contracts): catalogue read DTOs, asserted by Catalog itself"
+```
+
+---
+
+### Task 3: The gateway client
+
+**Files:**
+- Create: `apps/web/src/api/errors.ts`, `apps/web/src/api/request.ts`,
+  `apps/web/src/api/products.ts`, `apps/web/src/api/queryClient.ts`
+- Create: `apps/web/src/api/__tests__/request.test.ts`
+
+**Interfaces:**
+- Consumes: `ProductListItemSchema`, `ProductDetailSchema` from Task 2.
+- Produces: `request<T>(path, schema)`, `listProducts()`, `getProduct(id)`,
+  `NetworkError`, `HttpError` (with `.status`), `SchemaMismatchError`, `makeQueryClient()`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`apps/web/src/api/__tests__/request.test.ts`:
+
+```tsx
+import { z } from "zod";
+import { request } from "../request";
+import { HttpError, NetworkError, SchemaMismatchError } from "../errors";
+
+const schema = z.object({ id: z.string() });
+
+function mockFetch(impl: () => Promise<Response> | never) {
+  vi.stubGlobal("fetch", vi.fn(impl));
+}
+afterEach(() => vi.unstubAllGlobals());
+
+it("returns parsed data on a valid response", async () => {
+  mockFetch(async () => new Response(JSON.stringify({ id: "p1" }), { status: 200 }));
+  await expect(request("/products", schema)).resolves.toEqual({ id: "p1" });
+});
+
+it("throws HttpError carrying the status on a non-2xx", async () => {
+  mockFetch(async () => new Response("nope", { status: 404 }));
+  const err = await request("/products", schema).catch((e) => e);
+  expect(err).toBeInstanceOf(HttpError);
+  expect((err as HttpError).status).toBe(404);
+});
+
+it("throws NetworkError when fetch itself rejects", async () => {
+  mockFetch(() => Promise.reject(new TypeError("failed to fetch")));
+  await expect(request("/products", schema)).rejects.toBeInstanceOf(NetworkError);
+});
+
+// The drift alarm. A shape mismatch is a BUG, not a user-facing condition, so it must be
+// distinguishable from a 4xx or a dropped connection.
+it("throws SchemaMismatchError when the body does not match the schema", async () => {
+  mockFetch(async () => new Response(JSON.stringify({ id: 42 }), { status: 200 }));
+  await expect(request("/products", schema)).rejects.toBeInstanceOf(SchemaMismatchError);
+});
+
+it("requests a same-origin path, never an absolute gateway URL", async () => {
+  const spy = vi.fn(async () => new Response(JSON.stringify({ id: "p1" }), { status: 200 }));
+  vi.stubGlobal("fetch", spy);
+  await request("/products", schema);
+  expect(spy.mock.calls[0][0]).toBe("/products");
+});
+```
+
+- [ ] **Step 2: Run and confirm it fails**
+
+Run: `pnpm vitest run apps/web/src/api/__tests__/request.test.ts`
+Expected: FAIL — cannot resolve `../request`.
+
+- [ ] **Step 3: Write the error types**
+
+`apps/web/src/api/errors.ts`:
+
+```ts
+// Three failures that need three different responses (spec §B3). Collapsing the third into a
+// generic error is how a contract violation gets mistaken for an empty catalogue.
+export class NetworkError extends Error {
+  constructor(cause: unknown) {
+    super("the gateway could not be reached");
+    this.name = "NetworkError";
+    this.cause = cause;
+  }
+}
+
+export class HttpError extends Error {
+  constructor(readonly status: number) {
+    super(`the gateway answered ${status}`);
+    this.name = "HttpError";
+  }
+}
+
+export class SchemaMismatchError extends Error {
+  constructor(
+    readonly path: string,
+    readonly detail: string
+  ) {
+    super(`response from ${path} did not match its contract: ${detail}`);
+    this.name = "SchemaMismatchError";
+  }
+}
+```
+
+- [ ] **Step 4: Write the request helper**
+
+`apps/web/src/api/request.ts`:
+
+```ts
+import type { ZodType } from "zod";
+import { HttpError, NetworkError, SchemaMismatchError } from "./errors";
+
+// The only module that knows HTTP exists. Everything above it receives typed values or typed
+// errors. Paths are ALWAYS same-origin — Vite (dev) and nginx (prod) proxy them to the
+// gateway, so no absolute URL and no gateway host ever enters the bundle.
+export async function request<T>(path: string, schema: ZodType<T>): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(path, { headers: { accept: "application/json" } });
+  } catch (cause) {
+    throw new NetworkError(cause);
+  }
+
+  if (!res.ok) throw new HttpError(res.status);
+
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch (cause) {
+    throw new SchemaMismatchError(path, `body was not JSON (${String(cause)})`);
+  }
+
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) throw new SchemaMismatchError(path, parsed.error.message);
+  return parsed.data;
+}
+```
+
+- [ ] **Step 5: Run and confirm green**
+
+Run: `pnpm vitest run apps/web/src/api/__tests__/request.test.ts`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 6: Write the product resources**
+
+`apps/web/src/api/products.ts`:
+
+```ts
+import { z } from "zod";
+import { ProductDetailSchema, ProductListItemSchema } from "@ecom/contracts";
+import { request } from "./request";
+
+// GET /products takes NO parameters — Catalog serves the whole catalogue in one response
+// (findMany with no take/skip). Sending ?limit= would imply a pagination that does not exist.
+export const listProducts = () => request("/products", z.array(ProductListItemSchema));
+
+export const getProduct = (id: string) =>
+  request(`/products/${encodeURIComponent(id)}`, ProductDetailSchema);
+```
+
+- [ ] **Step 7: Write the query client with the retry policy pinned**
+
+`apps/web/src/api/queryClient.ts`:
+
+```ts
+import { QueryClient } from "@tanstack/react-query";
+import { NetworkError } from "./errors";
+
+// React Query retries 3x on EVERY error by default. Left alone that contradicts the error
+// taxonomy outright: a SchemaMismatchError is a bug that must surface at once, and a 404 is
+// for a product that will never exist. Retry network failures only.
+export const makeQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: (failureCount, error) => error instanceof NetworkError && failureCount < 2,
+        staleTime: 30_000,
+      },
+    },
+  });
+```
+
+- [ ] **Step 8: Write the retry-policy test**
+
+Append to `apps/web/src/api/__tests__/request.test.ts`:
+
+```tsx
+import { makeQueryClient } from "../queryClient";
+
+it("retries network failures but never schema mismatches or 4xx", () => {
+  const retry = makeQueryClient().getDefaultOptions().queries!.retry as (
+    n: number,
+    e: Error
+  ) => boolean;
+  expect(retry(0, new NetworkError("x"))).toBe(true);
+  expect(retry(0, new SchemaMismatchError("/products", "bad"))).toBe(false);
+  expect(retry(0, new HttpError(404))).toBe(false);
+  expect(retry(5, new NetworkError("x"))).toBe(false); // bounded
+});
+```
+
+- [ ] **Step 9: Run, typecheck and commit**
+
+```bash
+pnpm vitest run apps/web
+pnpm typecheck && pnpm lint
+git add apps/web/src/api
+git commit -m "feat(web): gateway client with a typed error taxonomy and pinned retries"
+```
+
+---
+
+### Task 4: Design tokens and primitives
+
+**Files:**
+- Modify: `apps/web/src/styles.css`
+- Create: `apps/web/src/components/{Button,Badge,Card,Price,Skeleton,EmptyState,ErrorState,Silhouette}.tsx`
+- Create: `apps/web/src/components/__tests__/{Price,Silhouette}.test.tsx`
+
+**Interfaces:**
+- Produces: `<Price minorUnits={number} />`, `<Silhouette type={ProductType} />`, `<Card>`,
+  `<Badge>`, `<Button>`, `<Skeleton>`, `<EmptyState>`, `<ErrorState>`.
+
+- [ ] **Step 1: Declare the tokens once**
+
+Replace `apps/web/src/styles.css`. Values are lifted verbatim from the approved prototype;
+Tailwind v4 is CSS-first, so `@theme` both declares the variables and generates utilities.
+**No component may hard-code any of these values** (Global Constraint 7).
+
+```css
+@import "tailwindcss";
+
+@theme {
+  --color-paper: #f1f1f4;
+  --color-surface: #ffffff;
+  --color-surface-2: #f4f4f7;
+  --color-ink: #1d1d1f;
+  --color-ink-soft: #3c3c42;
+  --color-muted: #6e6e76;
+  --color-line: #e8e8ed;
+  --color-line-strong: #dcdce3;
+
+  /* Reserved to encode saga state — unused in 8a on purpose (spec §D). */
+  --color-live: #b26a12;
+  --color-live-bg: #fbf0de;
+  --color-ok: #2e7d46;
+  --color-ok-bg: #e4f1e8;
+  --color-fail: #c0392b;
+  --color-fail-bg: #fbe6e3;
+  --color-focus: #2f73e8;
+
+  --radius-sm: 12px;
+  --radius-DEFAULT: 16px;
+  --radius-lg: 24px;
+
+  --shadow-1: 0 1px 2px rgba(20, 20, 30, 0.05), 0 6px 18px rgba(20, 20, 30, 0.06);
+  --shadow-2: 0 4px 12px rgba(20, 20, 30, 0.08), 0 24px 52px rgba(20, 20, 30, 0.12);
+
+  --font-sans:
+    -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", Roboto, Helvetica, Arial,
+    sans-serif;
+  --font-mono:
+    ui-monospace, "SF Mono", "Cascadia Code", "JetBrains Mono", Menlo, Consolas, monospace;
+}
+
+/* Dark values ship now; the toggle is 8c. Media query only. */
+@media (prefers-color-scheme: dark) {
+  @theme {
+    --color-paper: #0c0c0f;
+    --color-surface: #191a1e;
+    --color-surface-2: #232429;
+    --color-ink: #f2f2f4;
+    --color-ink-soft: #c9cacd;
+    --color-muted: #909198;
+    --color-line: #2a2b31;
+    --color-line-strong: #3a3b42;
+    --color-live: #e4aa53;
+    --color-live-bg: #2c2616;
+    --color-ok: #5fbe7c;
+    --color-ok-bg: #14251a;
+    --color-fail: #e8776a;
+    --color-fail-bg: #2c1917;
+    --color-focus: #5c93f2;
+  }
+}
+
+body {
+  background: var(--color-paper);
+  color: var(--color-ink);
+  font-family: var(--font-sans);
+}
+
+/* Every datum — prices, ids, versions — is mono with tabular figures (spec §D). */
+.datum {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+```
+
+- [ ] **Step 2: Write the failing primitive tests**
+
+`apps/web/src/components/__tests__/Price.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { Price } from "../Price";
+
+it.each([
+  [900, "$9.00"],
+  [2450, "$24.50"],
+  [890000, "$8,900.00"],
+  [0, "$0.00"],
+])("renders %i minor units as %s", (minor, expected) => {
+  render(<Price minorUnits={minor} />);
+  expect(screen.getByText(expected)).toBeInTheDocument();
+});
+```
+
+`apps/web/src/components/__tests__/Silhouette.test.tsx`:
+
+```tsx
+import { render } from "@testing-library/react";
+import { Silhouette } from "../Silhouette";
+
+it.each(["ELECTRONICS", "CLOTHING", "FURNITURE", "MOTORBIKE"] as const)(
+  "renders a shape for %s",
+  (type) => {
+    const { container } = render(<Silhouette type={type} />);
+    expect(container.querySelector("svg")).not.toBeNull();
+  }
+);
+
+// Degrade, never crash: the union comes from a network response, so an unknown value is
+// reachable if Catalog ever adds a type before the storefront knows about it.
+it("degrades to a neutral shape for an unknown type", () => {
+  const { container } = render(
+    <Silhouette type={"SPACESHIP" as unknown as "ELECTRONICS"} />
+  );
+  expect(container.querySelector("svg")).not.toBeNull();
+});
+```
+
+- [ ] **Step 3: Run and confirm they fail**
+
+Run: `pnpm vitest run apps/web/src/components`
+Expected: FAIL — modules not found.
+
+- [ ] **Step 4: Implement Price and Silhouette**
+
+`apps/web/src/components/Price.tsx`:
+
+```tsx
+// price is integer MINOR UNITS everywhere in the system; this is the only place it becomes
+// a human number (Global Constraint 9).
+const fmt = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" });
+
+export function Price({ minorUnits }: { minorUnits: number }) {
+  return <span className="datum">{fmt.format(minorUnits / 100)}</span>;
+}
+```
+
+`apps/web/src/components/Silhouette.tsx`:
+
+```tsx
+import type { ProductType } from "@ecom/contracts";
+
+const PATHS: Record<ProductType, string> = {
+  ELECTRONICS: "M8 8h48v30H8zM4 44h56M26 38v6M38 38v6",
+  CLOTHING: "M24 6l8 6 8-6 12 8-6 8-6-3v18H24V19l-6 3-6-8z",
+  FURNITURE: "M14 24V12a6 6 0 016-6h24a6 6 0 016 6v12M10 24h44v10H10zM14 34v8M50 34v8",
+  MOTORBIKE: "M15 34l10-16h16l6 8M25 18l-4-6h10M41 18l16 16M31 34h20",
+};
+const FALLBACK = "M10 10h44v28H10z";
+
+export function Silhouette({ type }: { type: ProductType }) {
+  const d = PATHS[type] ?? FALLBACK;
+  return (
+    <svg
+      viewBox="0 0 64 48"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className="w-1/2 text-[color:var(--color-ink-soft)]"
+    >
+      <path d={d} />
+    </svg>
+  );
+}
+```
+
+- [ ] **Step 5: Implement the remaining primitives**
+
+`apps/web/src/components/Card.tsx`:
+
+```tsx
+import type { ReactNode } from "react";
+
+export function Card({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex flex-col overflow-hidden rounded-lg border border-[color:var(--color-line)] bg-[color:var(--color-surface)] shadow-[var(--shadow-1)]">
+      {children}
+    </div>
+  );
+}
+```
+
+`apps/web/src/components/Badge.tsx`:
+
+```tsx
+export function Badge({ children }: { children: string }) {
+  return (
+    <span className="datum rounded-full border border-[color:var(--color-line-strong)] bg-[color:var(--color-surface)] px-2 py-0.5 text-[10.5px] uppercase tracking-[0.12em] text-[color:var(--color-muted)]">
+      {children}
+    </span>
+  );
+}
+```
+
+`apps/web/src/components/Button.tsx`:
+
+```tsx
+import type { ButtonHTMLAttributes } from "react";
+
+export function Button({
+  children,
+  ...rest
+}: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      {...rest}
+      className="inline-flex h-11 items-center justify-center rounded border border-[color:var(--color-ink)] bg-[color:var(--color-ink)] px-5 text-sm text-[color:var(--color-paper)]"
+    >
+      {children}
+    </button>
+  );
+}
+```
+
+`apps/web/src/components/Skeleton.tsx`:
+
+```tsx
+// Matches the card geometry rather than being a spinner, so the grid does not reflow when
+// data lands.
+export function Skeleton() {
+  return (
+    <div
+      data-testid="skeleton"
+      className="h-64 animate-pulse rounded-lg bg-[color:var(--color-surface-2)]"
+    />
+  );
+}
+```
+
+`apps/web/src/components/EmptyState.tsx`:
+
+```tsx
+export function EmptyState({ message }: { message: string }) {
+  return (
+    <p className="rounded border border-dashed border-[color:var(--color-line-strong)] p-12 text-center text-[color:var(--color-muted)]">
+      {message}
+    </p>
+  );
+}
+```
+
+`apps/web/src/components/ErrorState.tsx`:
+
+```tsx
+import { HttpError, NetworkError, SchemaMismatchError } from "../api/errors";
+import { Button } from "./Button";
+
+// A schema mismatch is backend drift, not a user condition — it says so plainly rather than
+// rendering as "something went wrong", which is how a contract violation gets mistaken for an
+// empty catalogue.
+export function ErrorState({ error, onRetry }: { error: unknown; onRetry?: () => void }) {
+  const message =
+    error instanceof NetworkError
+      ? "Could not reach the store. Check your connection."
+      : error instanceof SchemaMismatchError
+        ? "The store sent data this page does not understand. This is a bug, not you."
+        : error instanceof HttpError
+          ? `The store answered ${error.status}.`
+          : "Something went wrong.";
+
+  return (
+    <div role="alert" className="p-12 text-center">
+      <p className="text-[color:var(--color-muted)]">{message}</p>
+      {error instanceof NetworkError && onRetry ? (
+        <div className="mt-4">
+          <Button onClick={onRetry}>Try again</Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: Run, verify green, commit**
+
+```bash
+pnpm vitest run apps/web
+pnpm typecheck && pnpm lint && pnpm format:check
+git add apps/web/src/styles.css apps/web/src/components
+git commit -m "feat(web): design tokens from the prototype and the primitive set"
+```
+
+---
+
+### Task 5: Home — grid, filter, three async states
+
+**Files:**
+- Create: `apps/web/src/routes/Home.tsx`, `apps/web/src/components/ProductCard.tsx`
+- Create: `apps/web/src/routes/__tests__/Home.test.tsx`
+- Modify: `apps/web/src/App.tsx`, `apps/web/src/main.tsx`
+
+**Interfaces:**
+- Consumes: `listProducts()`, `makeQueryClient()` (Task 3); primitives (Task 4).
+- Produces: `<Home />`, `<ProductCard product={ProductListItem} />`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`apps/web/src/routes/__tests__/Home.test.tsx`:
+
+```tsx
+import { QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { makeQueryClient } from "../../api/queryClient";
+import { HttpError } from "../../api/errors";
+import * as api from "../../api/products";
+import { Home } from "../Home";
+
+function renderHome() {
+  return render(
+    <QueryClientProvider client={makeQueryClient()}>
+      <Home />
+    </QueryClientProvider>
+  );
+}
+const product = (over = {}) => ({
+  id: "p1",
+  type: "ELECTRONICS" as const,
+  name: "Widget",
+  price: 900,
+  version: 1,
+  ...over,
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+it("shows skeletons while loading", () => {
+  vi.spyOn(api, "listProducts").mockReturnValue(new Promise(() => {}));
+  renderHome();
+  expect(screen.getAllByTestId("skeleton").length).toBeGreaterThan(0);
+});
+
+it("renders a card per product once loaded", async () => {
+  vi.spyOn(api, "listProducts").mockResolvedValue([
+    product(),
+    product({ id: "p2", name: "Shirt", type: "CLOTHING", price: 2450 }),
+  ]);
+  renderHome();
+  expect(await screen.findByText("Widget")).toBeInTheDocument();
+  expect(screen.getByText("Shirt")).toBeInTheDocument();
+  expect(screen.getByText("$9.00")).toBeInTheDocument();
+});
+
+it("shows the empty state for an empty catalogue", async () => {
+  vi.spyOn(api, "listProducts").mockResolvedValue([]);
+  renderHome();
+  expect(await screen.findByText(/no products/i)).toBeInTheDocument();
+});
+
+it("shows the error state when the gateway errors", async () => {
+  vi.spyOn(api, "listProducts").mockRejectedValue(new HttpError(500));
+  renderHome();
+  expect(await screen.findByRole("alert")).toHaveTextContent("500");
+});
+
+it("filters by category", async () => {
+  vi.spyOn(api, "listProducts").mockResolvedValue([
+    product(),
+    product({ id: "p2", name: "Shirt", type: "CLOTHING" }),
+  ]);
+  renderHome();
+  expect(await screen.findByText("Widget")).toBeInTheDocument();
+  // fireEvent, not node.click(): a raw DOM click is not wrapped in act(), so the state
+  // update would not be flushed before the assertions below.
+  fireEvent.click(screen.getByRole("button", { name: /clothing/i }));
+  expect(screen.queryByText("Widget")).not.toBeInTheDocument();
+  expect(screen.getByText("Shirt")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run and confirm failure**
+
+Run: `pnpm vitest run apps/web/src/routes`
+Expected: FAIL — `../Home` not found.
+
+- [ ] **Step 3: Implement ProductCard**
+
+`apps/web/src/components/ProductCard.tsx`:
+
+```tsx
+import { Link } from "react-router";
+import type { ProductListItem } from "@ecom/contracts";
+import { Badge } from "./Badge";
+import { Card } from "./Card";
+import { Price } from "./Price";
+import { Silhouette } from "./Silhouette";
+
+export function ProductCard({ product }: { product: ProductListItem }) {
+  return (
+    <Link to={`/products/${product.id}`}>
+      <Card>
+        <div className="relative flex aspect-[4/3] items-center justify-center bg-[color:var(--color-surface-2)]">
+          <div className="absolute left-3 top-3">
+            <Badge>{product.type}</Badge>
+          </div>
+          <Silhouette type={product.type} />
+        </div>
+        <div className="flex flex-col gap-1 p-4">
+          <span className="text-[15px] font-medium">{product.name}</span>
+          <Price minorUnits={product.price} />
+        </div>
+      </Card>
+    </Link>
+  );
+}
+```
+
+- [ ] **Step 4: Implement Home**
+
+`apps/web/src/routes/Home.tsx`:
+
+```tsx
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import type { ProductType } from "@ecom/contracts";
+import { listProducts } from "../api/products";
+import { EmptyState } from "../components/EmptyState";
+import { ErrorState } from "../components/ErrorState";
+import { ProductCard } from "../components/ProductCard";
+import { Skeleton } from "../components/Skeleton";
+
+const CATEGORIES: (ProductType | "ALL")[] = [
+  "ALL",
+  "MOTORBIKE",
+  "ELECTRONICS",
+  "FURNITURE",
+  "CLOTHING",
+];
+
+export function Home() {
+  const [filter, setFilter] = useState<ProductType | "ALL">("ALL");
+  const { data, error, isPending, refetch } = useQuery({
+    queryKey: ["products"],
+    queryFn: listProducts,
+  });
+
+  if (isPending) {
+    return (
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+        {Array.from({ length: 8 }, (_, i) => (
+          <Skeleton key={i} />
+        ))}
+      </div>
+    );
+  }
+  if (error) return <ErrorState error={error} onRetry={() => void refetch()} />;
+
+  const shown = filter === "ALL" ? data : data.filter((p) => p.type === filter);
+
+  return (
+    <>
+      <div className="mb-4 flex flex-wrap gap-2">
+        {CATEGORIES.map((c) => (
+          <button
+            key={c}
+            onClick={() => setFilter(c)}
+            aria-pressed={filter === c}
+            className="datum rounded-full border border-[color:var(--color-line)] px-3 py-1.5 text-xs uppercase"
+          >
+            {c}
+          </button>
+        ))}
+      </div>
+      {shown.length === 0 ? (
+        <EmptyState message="No products in the catalogue yet." />
+      ) : (
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+          {shown.map((p) => (
+            <ProductCard key={p.id} product={p} />
+          ))}
+        </div>
+      )}
+    </>
+  );
+}
+```
+
+- [ ] **Step 5: Wire the router and provider**
+
+`apps/web/src/App.tsx`:
+
+```tsx
+import { createBrowserRouter, RouterProvider } from "react-router";
+import { Home } from "./routes/Home";
+
+const router = createBrowserRouter([{ path: "/", element: <Home /> }]);
+
+export function App() {
+  return <RouterProvider router={router} />;
+}
+```
+
+`apps/web/src/main.tsx` — wrap in the query provider:
+
+```tsx
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { App } from "./App";
+import { makeQueryClient } from "./api/queryClient";
+import "./styles.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <QueryClientProvider client={makeQueryClient()}>
+      <App />
+    </QueryClientProvider>
+  </StrictMode>
+);
+```
+
+Delete `apps/web/src/__tests__/smoke.test.tsx` — Task 1's placeholder heading is gone, and
+the Home tests supersede it.
+
+- [ ] **Step 6: Run, verify green, commit**
+
+```bash
+pnpm vitest run apps/web
+pnpm typecheck && pnpm lint && pnpm format:check
+git rm apps/web/src/__tests__/smoke.test.tsx
+git add apps/web/src
+git commit -m "feat(web): catalogue grid with loading, error and empty states"
+```
+
+---
+
+### Task 6: Product detail — attributes, 404, safe rendering
+
+**Files:**
+- Create: `apps/web/src/routes/Product.tsx`, `apps/web/src/routes/__tests__/Product.test.tsx`
+- Modify: `apps/web/src/App.tsx`
+
+**Interfaces:**
+- Consumes: `getProduct(id)` (Task 3), primitives (Task 4).
+- Produces: `<Product />` mounted at `/products/:id`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`apps/web/src/routes/__tests__/Product.test.tsx`:
+
+```tsx
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { makeQueryClient } from "../../api/queryClient";
+import { HttpError } from "../../api/errors";
+import * as api from "../../api/products";
+import { Product } from "../Product";
+
+function renderAt(id: string) {
+  const router = createMemoryRouter([{ path: "/products/:id", element: <Product /> }], {
+    initialEntries: [`/products/${id}`],
+  });
+  return render(
+    <QueryClientProvider client={makeQueryClient()}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  );
+}
+const detail = (over = {}) => ({
+  id: "p1",
+  type: "ELECTRONICS" as const,
+  name: "Widget",
+  price: 900,
+  version: 3,
+  attributes: { manufacturer: "Acme" },
+  ...over,
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+it("renders name, price and the attributes table", async () => {
+  vi.spyOn(api, "getProduct").mockResolvedValue(detail());
+  renderAt("p1");
+  expect(await screen.findByText("Widget")).toBeInTheDocument();
+  expect(screen.getByText("$9.00")).toBeInTheDocument();
+  expect(screen.getByText("manufacturer")).toBeInTheDocument();
+  expect(screen.getByText("Acme")).toBeInTheDocument();
+});
+
+// Reachable with nothing broken: a stale link, or a product removed between list and click.
+it("renders a not-found view on 404, not a generic error", async () => {
+  vi.spyOn(api, "getProduct").mockRejectedValue(new HttpError(404));
+  renderAt("gone");
+  expect(await screen.findByText(/not found/i)).toBeInTheDocument();
+  expect(screen.getByRole("link", { name: /catalogue/i })).toBeInTheDocument();
+});
+
+it("still shows the error state for a non-404", async () => {
+  vi.spyOn(api, "getProduct").mockRejectedValue(new HttpError(500));
+  renderAt("p1");
+  expect(await screen.findByRole("alert")).toHaveTextContent("500");
+});
+
+// attributes is z.record(z.unknown()) — values are genuinely unknown at compile time.
+it("renders primitive attributes and skips non-primitive ones", async () => {
+  vi.spyOn(api, "getProduct").mockResolvedValue(
+    detail({ attributes: { brand: "Acme", sizes: { eu: 42 }, inStock: true } })
+  );
+  renderAt("p1");
+  expect(await screen.findByText("brand")).toBeInTheDocument();
+  expect(screen.getByText("true")).toBeInTheDocument();
+  expect(screen.queryByText("sizes")).not.toBeInTheDocument();
+  expect(screen.queryByText(/object Object/)).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run and confirm failure**
+
+Run: `pnpm vitest run apps/web/src/routes/__tests__/Product.test.tsx`
+Expected: FAIL — `../Product` not found.
+
+- [ ] **Step 3: Implement Product**
+
+`apps/web/src/routes/Product.tsx`:
+
+```tsx
+import { useQuery } from "@tanstack/react-query";
+import { Link, useParams } from "react-router";
+import { HttpError } from "../api/errors";
+import { getProduct } from "../api/products";
+import { Badge } from "../components/Badge";
+import { ErrorState } from "../components/ErrorState";
+import { Price } from "../components/Price";
+import { Silhouette } from "../components/Silhouette";
+import { Skeleton } from "../components/Skeleton";
+
+// attributes values are `unknown` by contract. Render primitives; skip everything else rather
+// than emitting "[object Object]". Values are API-sourced strings, so they go through React's
+// normal escaping — never dangerouslySetInnerHTML.
+function primitiveEntries(attributes: Record<string, unknown>) {
+  return Object.entries(attributes).filter(
+    ([, v]) => typeof v === "string" || typeof v === "number" || typeof v === "boolean"
+  ) as [string, string | number | boolean][];
+}
+
+export function Product() {
+  const { id = "" } = useParams();
+  const { data, error, isPending, refetch } = useQuery({
+    queryKey: ["product", id],
+    queryFn: () => getProduct(id),
+  });
+
+  if (isPending) return <Skeleton />;
+
+  if (error instanceof HttpError && error.status === 404) {
+    return (
+      <div className="p-12 text-center">
+        <h1 className="text-2xl">Product not found</h1>
+        <p className="mt-2 text-[color:var(--color-muted)]">
+          It may have been removed since you last looked.
+        </p>
+        <Link to="/" className="datum mt-4 inline-block underline">
+          Back to the catalogue
+        </Link>
+      </div>
+    );
+  }
+  if (error) return <ErrorState error={error} onRetry={() => void refetch()} />;
+
+  return (
+    <div className="grid gap-8 md:grid-cols-2">
+      <div className="flex aspect-[4/3] items-center justify-center rounded-lg border border-[color:var(--color-line)] bg-[color:var(--color-surface-2)]">
+        <Silhouette type={data.type} />
+      </div>
+      <div className="flex flex-col gap-4">
+        <Badge>{data.type}</Badge>
+        <h1 className="text-3xl">{data.name}</h1>
+        <Price minorUnits={data.price} />
+        <dl className="border-t border-[color:var(--color-line)]">
+          {primitiveEntries(data.attributes).map(([k, v]) => (
+            <div
+              key={k}
+              className="flex justify-between border-b border-[color:var(--color-line)] py-2"
+            >
+              <dt className="datum text-xs uppercase text-[color:var(--color-muted)]">{k}</dt>
+              <dd className="datum">{String(v)}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Add the route**
+
+In `apps/web/src/App.tsx`, extend the router:
+
+```tsx
+import { createBrowserRouter, RouterProvider } from "react-router";
+import { Home } from "./routes/Home";
+import { Product } from "./routes/Product";
+
+const router = createBrowserRouter([
+  { path: "/", element: <Home /> },
+  { path: "/products/:id", element: <Product /> },
+]);
+
+export function App() {
+  return <RouterProvider router={router} />;
+}
+```
+
+- [ ] **Step 5: Run and confirm green**
+
+Run: `pnpm vitest run apps/web`
+Expected: PASS, all suites.
+
+- [ ] **Step 6: Verify against the real stack**
+
+With the stack up (`docker compose -f docker-compose.example.yml --profile app up -d`):
+
+```bash
+pnpm --filter @ecom/web dev
+```
+
+Open `http://localhost:5173`. Confirm: the grid lists real products, a card navigates to
+detail, the attributes table shows real values, and `http://localhost:5173/products/nope`
+renders "Product not found". Confirm in devtools that requests go to `/products` on
+**port 5173**, not to 8000 — proof the proxy, not CORS, is carrying them.
+
+- [ ] **Step 7: Commit**
+
+```bash
+pnpm typecheck && pnpm lint && pnpm format:check
+git add apps/web/src
+git commit -m "feat(web): product detail with a real 404 view and safe attribute rendering"
+```
+
+---
+
+### Task 7: Documentation amendments
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-18-microservices-streaming-rebuild-design.md`
+- Modify: `docs/superpowers/specs/2026-07-23-phases-3-8-roadmap.md`
+
+- [ ] **Step 1: Amend the umbrella's Storefront DoD**
+
+In the "Storefront Definition of Done" list, replace the dual-build bullet:
+
+```markdown
+- [ ] `apps/*` added to `pnpm-workspace.yaml`. `packages/contracts` is consumed as
+      **TypeScript source** via its `main: src/index.ts`, exactly as all eight services
+      consume it in dev and production (see each service Dockerfile's "NO tsc build step"
+      comment). **A dual ESM+CJS build was specified here and withdrawn in 8a**: nothing in
+      the repo imports `contracts/dist`, so the stated reason — "so the ESM/Vite app can
+      import the (CJS) contracts cleanly" — did not hold.
+```
+
+And amend the config bullet:
+
+```markdown
+- [ ] Env-based config (Gateway URL) at the **proxy layer** — Vite's dev server and 8c's
+      nginx — so no gateway host and zero secrets enter the bundle.
+```
+
+- [ ] **Step 2: Amend the roadmap's 8a line**
+
+In §Phase 8 Slices, replace slice 1's opening clause:
+
+```markdown
+1. **8a — Foundation + catalogue:** `apps/*` into `pnpm-workspace.yaml` with
+   `packages/contracts` consumed as TypeScript source (**the dual ESM+CJS build originally
+   specified here was withdrawn in 8a — see that child spec §A1**); `apps/web` (Vite + React
+   + TS + Tailwind); gateway client with zod boundary validation, with **Catalog asserting
+   its own responses against the shared schemas**; home/product views with loading/error/empty
+   states. Stock is **not** shown — it lives in Inventory, which the gateway does not mount.
+```
+
+- [ ] **Step 3: Verify nothing else contradicts**
+
+```bash
+grep -n "dual ESM\|CJS" docs/superpowers/specs/*.md
+```
+
+Every remaining hit must be one of the two amendments above or the 8a child spec's own §A1/§G.
+
+- [ ] **Step 4: Commit**
+
+```bash
+pnpm format:check
+git add docs/superpowers/specs/2026-07-18-microservices-streaming-rebuild-design.md docs/superpowers/specs/2026-07-23-phases-3-8-roadmap.md
+git commit -m "docs(8a): withdraw the dual-build requirement and record the amendments"
+```
+
+---
+
+## Notes for the executor
+
+- **Global Constraint 1 is not optional.** If `vitest.config.ts` has only two globs on your
+  base, you are on the wrong base — stop and rebase onto one containing 7d.
+- **Every RED step must actually fail for the stated reason.** A test that fails because a
+  module is missing has not yet proven the behaviour it describes; once it passes, satisfy
+  yourself it would fail if the behaviour were removed. Task 2 Step 6 does this explicitly
+  because that test is the drift alarm the whole slice rests on.
+- Task 6 Step 6 is the only step needing the full stack. Everything else runs offline.
+- Deviations go in `.scratch/phase-8a/impl-notes.html` and in the final digest's
+  `Deviations:` section.

--- a/docs/superpowers/specs/2026-07-18-microservices-streaming-rebuild-design.md
+++ b/docs/superpowers/specs/2026-07-18-microservices-streaming-rebuild-design.md
@@ -348,9 +348,17 @@ build time. Playwright (frontend e2e) joins the Testing inventory above.
 
 **Storefront Definition of Done**
 - [ ] Talks only to the Gateway; DTOs imported from `contracts`; responses zod-validated.
-- [ ] `apps/*` added to `pnpm-workspace.yaml`; `packages/contracts` builds **dual
-      ESM+CJS** so the ESM/Vite app can import the (CJS) contracts cleanly.
-- [ ] Env-based config (Gateway URL); zero secrets in the bundle.
+- [ ] `apps/*` added to `pnpm-workspace.yaml`. `packages/contracts` is consumed as
+      **TypeScript source** via its `main: src/index.ts`, exactly as all eight services
+      consume it in dev and production (see each service Dockerfile's "NO tsc build step"
+      comment). **A dual ESM+CJS build was specified here and withdrawn in 8a**: nothing in
+      the repo imports `contracts/dist`, so the stated reason — "so the ESM/Vite app can
+      import the (CJS) contracts cleanly" — did not hold.
+- [ ] Env-based config (Gateway URL) at the **proxy layer** — Vite's dev server and 8c's
+      nginx — so no gateway host and zero secrets enter the bundle. The browser calls
+      same-origin **`/api/*`**, which the proxy strips before forwarding; 8a rooted those
+      paths at `/products` first and found the API prefix shadowing the storefront's own
+      `/products/:id` page, so a hard refresh returned JSON instead of the app.
 - [ ] Loading / error / empty state for every async view.
 - [ ] Auth: login/register via Identity; JWT in an **httpOnly Secure SameSite
       cookie** (never in JS); **CSRF token** on mutations; protected routes.

--- a/docs/superpowers/specs/2026-07-23-phases-3-8-roadmap.md
+++ b/docs/superpowers/specs/2026-07-23-phases-3-8-roadmap.md
@@ -128,11 +128,22 @@ Effectively greenfield (legacy is a stub). The **RabbitMQ showcase** phase.
 Per the umbrella's §Phase 8 design (stack, flows, design language, DoD locked there).
 
 **Slices**
-1. **8a — Foundation + catalogue:** **contracts dual ESM+CJS build FIRST, CI-gated** (exports map; gate = ALL consuming services — by then hello/inventory/order/payment/catalog/notification/identity/gateway — stay green); `apps/web` (Vite + React + TS + Tailwind) into `pnpm-workspace.yaml`; gateway client with zod boundary validation; home/product views with loading/error/empty states.
+1. **8a — Foundation + catalogue:** `apps/*` into `pnpm-workspace.yaml` with
+   `packages/contracts` consumed as TypeScript source (**the dual ESM+CJS build originally
+   specified here was withdrawn in 8a — see that child spec §A1**); `apps/web` (Vite + React
+   + TS + Tailwind); gateway client with zod boundary validation, reaching the gateway over a
+   same-origin **`/api/*`** prefix the dev proxy strips, with **Catalog asserting its own
+   responses against the shared schemas**; home/product views with loading/error/empty
+   states. Stock is **not** shown — it lives in Inventory, which the gateway does not mount.
 2. **8b — Auth + cart + checkout:** cookie login/register, CSRF on mutations, protected routes, cart, place order.
 3. **8c — Order-pipeline tracker + polish:** SSE tracker (the signature element, per the approved prototype), polling fallback, order history, a11y + `prefers-reduced-motion`, Playwright e2e, Dockerfile + prod profile.
 
-**Risks:** dual-build breaking the consuming services → do it first, contract tests against both outputs; EventSource + cookie via proxy → de-risked in 6b, verify the fallback; tracker design bar → prototype is the reference, component tests per saga-state rendering.
+**Risks:** ~~dual-build breaking the consuming services~~ — withdrawn in 8a, so the risk is
+gone with it; instead, contracts drifting from what Catalog actually serves → **Catalog
+asserts its own responses against the shared schemas**, so drift fails a backend test beside
+the change that caused it; EventSource + cookie via proxy → de-risked in 6b, verify the
+fallback; tracker design bar → prototype is the reference, component tests per saga-state
+rendering.
 
 **Parked for child specs:** React 18 vs 19 (umbrella: latest at build time); SSE frame DTO shape in contracts; Playwright in CI vs local-only. Note: the CI `quality` job auto-globs only `services/*` — `apps/web` needs hand-wiring + a Playwright lane.
 
@@ -166,7 +177,7 @@ Serial per policy. The only theoretically parallelizable pair is **3 ∥ 4** (ne
 | Compose: mailpit | **5** |
 | Compose: prometheus / grafana / jaeger | **7** |
 | Per-service compose `app` entries + hand-added CI integration steps | every phase (part of its DoD) |
-| Contracts dual ESM+CJS build | **8** (8a, first slice, CI-gated) |
+| ~~Contracts dual ESM+CJS build~~ — **withdrawn in 8a**; contracts stays TypeScript source | — |
 | Gateway timeouts + circuit breaker (umbrella §Resilience) | **6** (6b) |
 | `x-user-id` → verified-identity retrofit across existing services | **6** (6b) |
 | Dedup-pattern guidance in `shared` (ProcessedEvent vs Redis `markProcessed`) | **5** (5a decides + documents) |

--- a/docs/superpowers/specs/2026-07-30-phase-8a-storefront-foundation-design.md
+++ b/docs/superpowers/specs/2026-07-30-phase-8a-storefront-foundation-design.md
@@ -33,6 +33,27 @@ evidence).
 contract tests (§B2). No route, handler, schema or config in any of the eight services is
 modified, so 8a cannot regress the system it renders.
 
+## Preconditions — 8a implements on top of 7d, not beside it
+
+This spec is committed on a branch off `origin/main`, which does **not** contain Phase 7d
+(PR #7, open as a draft). That is fine for a documentation commit and wrong for the
+implementation, because the two slices edit the same two files:
+
+| File | 7d does | 8a does |
+|---|---|---|
+| `vitest.config.ts` | added the `infra/**` glob | replaces it with `vitest.workspace.ts` (§E) |
+| `eslint.config.js` | added a `k6/**` block | adds an `apps/web` block (§E) |
+
+Left unstated, the likeliest conflict resolution silently drops 7d's `infra` project and
+re-creates precisely the uncovered-suite gap 7d existed to close. So:
+
+- **8a implementation starts from a base that contains 7d** — either 7d's head, or `main`
+  once #7 merges. The latter is preferred, and keeps the one-open-PR policy intact.
+- **`vitest.workspace.ts` must carry an `infra` project forward**, not just `packages`,
+  `services` and the new `apps/web`. §E's "the existing three projects" counts 7d's infra
+  glob; on this spec's own base there are only two, which is the tell that the base is wrong
+  for implementation.
+
 ## A. What the roadmap got wrong, and what replaces it
 
 ### A1. The dual ESM+CJS contracts build is not needed, and never was
@@ -107,6 +128,10 @@ type-specific attributes with per-type schemas it owns; restating them in a shar
 would create a second source of truth to keep in sync, which is the drift this section exists
 to prevent.
 
+`version` is carried in both DTOs though no 8a view renders it. It is Catalog's optimistic
+concurrency counter and the field its projection ordering keys on, so having it at the
+boundary makes a stale-cache question answerable later without a contract change.
+
 `price` is **integer minor units** — "Widget" is `900`, meaning $9.00. Formatting divides by
 100 at the presentation layer and nowhere else.
 
@@ -176,6 +201,13 @@ React Query holds server state. **No global store**: the only client state 8a ha
 current category filter, and cart state arrives in 8b. Inventing a store now would be
 speculative structure for a need that has not appeared.
 
+**The retry policy is pinned, not defaulted.** React Query retries a failed query three times
+for *every* error type. Left alone that contradicts §B3 outright: a schema mismatch — a bug —
+would be retried three times before surfacing, and a 404 would be retried for a product that
+will never exist. The query client therefore retries **network failures only**, never a
+schema mismatch and never a 4xx. This is the kind of default that silently makes a drift
+alarm slower and quieter, which is the opposite of what §B3 is for.
+
 ### C3. Views
 
 **Home** — hero, category filter chips, product grid. **Product detail** — figure, name,
@@ -185,6 +217,19 @@ for the prototype's invented `specs`.
 Every async view has three states, per the DoD: loading (skeletons matching the card
 geometry, not a spinner), error (§B3's taxonomy), and empty (a catalogue with no products is
 a real state, and after 7d's cleanup the dev database can genuinely be near-empty).
+
+**A 404 on product detail is its own case**, distinct from all three. It is reachable without
+anything being broken — a stale link, a shared URL, a product removed between the list
+rendering and the click — so it renders a "product not found" view with a route back to the
+catalogue, never a generic error and never an empty page.
+
+**Rendering `attributes` safely.** The map is `z.record(z.unknown())` (§B1), so its values are
+genuinely unknown at compile time. The table renders **primitive values only** — string,
+number, boolean — and skips anything else rather than emitting `[object Object]`. And because
+these strings originate from an API rather than from the app, **no API-sourced value is ever
+passed to `dangerouslySetInnerHTML`**; React's default escaping is the whole XSS defence here
+and nothing may opt out of it. A Content-Security-Policy belongs with 8c's nginx, which is
+where the app first gets served by something that can set headers.
 
 ## D. Design system
 
@@ -218,13 +263,15 @@ prototype's four.
 `pnpm typecheck` and `pnpm -r build` are recursive, so `apps/web` is covered **automatically**
 once it joins the workspace: CI typechecks it and builds the bundle with no workflow edit.
 
-Tests are the gap. Root `vitest.config.ts` includes only `packages/**`, `services/**` and
-`infra/**`, so `apps/web` tests would silently not run — and they need `jsdom`, which the
-existing node-environment suites must not inherit.
+Tests are the gap. Root `vitest.config.ts` includes only `packages/**`, `services/**` and —
+**once 7d is in the base, per §Preconditions** — `infra/**`. `apps/web` tests would silently
+not run, and they need `jsdom`, which the existing node-environment suites must not inherit.
 
-**A `vitest.workspace.ts` with two projects** resolves both: the existing three globs keep
-their current config verbatim, and `apps/web` gets jsdom plus an RTL setup file. One
-`pnpm vitest run` then covers everything, locally and in CI, with no new workflow step.
+**A `vitest.workspace.ts`** resolves both: every existing glob keeps its current config
+verbatim as its own project, and `apps/web` gets jsdom plus an RTL setup file. One
+`pnpm vitest run` then covers everything, locally and in CI, with no new workflow step. The
+`infra` project is explicitly part of "every existing glob" — dropping it is the failure mode
+§Preconditions exists to prevent.
 
 The rejected alternative is a bespoke `pnpm --filter @ecom/web test` CI step, which leaves
 `pnpm vitest run` quietly missing a project for anyone running it locally. That is precisely
@@ -252,7 +299,7 @@ No Playwright — 8c. Whether it runs in CI or locally stays parked, per the roa
 |---|---|---|
 | 1 | 8a is foundation + catalogue only | The dual-build question and the workspace seam are the risky parts; resolve them before UI volume |
 | 2 | Contracts consumed as source; no dual build | §A1 — the stated premise is false and the alternative regresses eight services |
-| 3 | React 19 | The umbrella says "latest at build time"; Router 7 and Query 5 both support it |
+| 3 | React 19 | The umbrella says "latest at build time". Router 7 and Query 5 are believed to support it; the plan pins and records the exact resolved versions rather than trusting this line |
 | 4 | No stock in the catalogue | §A2 — unreachable through the gateway |
 | 5 | Same-origin via proxy, not CORS | §C1 — no backend change, and 8b's cookies work |
 | 6 | Catalog asserts the shared schemas | §B2 — client-only validation does not prevent drift |
@@ -287,7 +334,10 @@ parked for 8c.
 - [ ] Every gateway response is zod-validated at the boundary; schema mismatch is a distinct,
       loud error, never an empty grid.
 - [ ] Home grid and product detail each render loading, error and empty states.
-- [ ] Design tokens match the approved prototype exactly, including dark values.
+- [ ] Design tokens are declared **once**, as CSS variables carrying the prototype's values
+      including the dark set — no hard-coded colour, radius or shadow literal anywhere in a
+      component. (Fidelity to the prototype is a review-time judgement; single-declaration is
+      the part a reviewer can actually check.)
 - [ ] `pnpm vitest run` covers `apps/web` through `vitest.workspace.ts`, with the existing
       three projects unchanged.
 - [ ] Browser talks only to same-origin paths; no CORS middleware added to the gateway; no

--- a/docs/superpowers/specs/2026-07-30-phase-8a-storefront-foundation-design.md
+++ b/docs/superpowers/specs/2026-07-30-phase-8a-storefront-foundation-design.md
@@ -1,0 +1,306 @@
+# Phase 8a · Storefront foundation + catalogue — Design (child spec)
+
+> Phase 8 (Storefront, L) is decomposed into three slices — **8a foundation + catalogue**
+> (this doc), 8b auth + cart + checkout, 8c order-pipeline tracker + polish. See
+> `docs/superpowers/specs/2026-07-23-phases-3-8-roadmap.md` §Phase 8 and the umbrella's
+> §Phase 8 · Storefront (design), which locks the stack, flows, design language and DoD.
+
+## Purpose
+
+Seven phases built a system with no face. 8a puts the first one on it: a real Vite + React
+app in the workspace, talking to the gateway and nothing else, rendering the catalogue that
+Catalog already serves.
+
+The slice is deliberately the thinnest vertical that proves the seam. Everything downstream —
+auth, cart, checkout, the saga tracker — rides on the same three things 8a establishes: how
+the app joins the workspace, how it reaches the gateway, and how a gateway response becomes a
+typed value the UI can trust. Get those wrong and every later slice inherits it.
+
+## Scope
+
+**In.** `apps/web` added to the pnpm workspace (Vite + React 19 + TypeScript + Tailwind).
+Read-API DTOs added to `packages/contracts`, with Catalog asserting its own responses against
+them. A gateway client that validates every response at the boundary. Home grid and product
+detail, each with loading, error and empty states. Design tokens lifted from the approved
+prototype. Component tests (Vitest + RTL) wired so one `pnpm vitest run` covers them.
+
+**Out.** Auth, cart, checkout (**8b**). SSE order tracker, order history, a11y sweep,
+`prefers-reduced-motion`, Playwright, Dockerfile and prod compose profile (**8c**). Stock
+display (§C3). A dual ESM+CJS contracts build (§A1 — the requirement is withdrawn, with
+evidence).
+
+**No backend change**, with one exception that adds only test assertions: Catalog gains
+contract tests (§B2). No route, handler, schema or config in any of the eight services is
+modified, so 8a cannot regress the system it renders.
+
+## A. What the roadmap got wrong, and what replaces it
+
+### A1. The dual ESM+CJS contracts build is not needed, and never was
+
+The roadmap opens 8a with "**contracts dual ESM+CJS build FIRST, CI-gated** (gate = ALL
+consuming services stay green)", and the umbrella DoD explains why: "so the ESM/Vite app can
+import the (CJS) contracts cleanly."
+
+Both halves of that premise are false, and the code says so out loud:
+
+- `packages/contracts/package.json` sets `"main": "src/index.ts"` and `"types":
+  "src/index.ts"` — it resolves to **TypeScript source**, not to CJS output.
+- Every service runs `tsx src/main.ts`. Nothing in the repo imports `contracts/dist`; the
+  `build` script emits output that no consumer reads.
+- This is deliberate and documented. Every service Dockerfile carries the comment: *"Runtime
+  executes the TypeScript entrypoint directly via tsx (see CMD), so there is NO tsc build
+  step: @ecom/shared and @ecom/contracts are consumed as source through their package
+  `main: src/index.ts`."* It holds in production, not just in dev.
+
+So contracts is never consumed as CJS by anyone, and Vite resolves a linked workspace package
+of TypeScript source the same way the services do.
+
+**Replacement:** add `apps/*` to `pnpm-workspace.yaml` and import `@ecom/contracts` source
+directly. The CI gate the roadmap wanted becomes trivially green because **no service's
+resolution changes at all** — which is the point. Switching every consumer to built output
+would contradict a deliberate architecture decision, add a build step before any service can
+run, and put the riskiest possible change at the front of a frontend slice.
+
+Residual risk is confined to Vite: a symlinked TS workspace package can need `optimizeDeps`
+or `preserveSymlinks` tuning. That risk is ours alone and costs a config line; the discarded
+alternative's risk was spread across eight services.
+
+**Amendment recorded** (§G1): the umbrella DoD line and the roadmap 8a line are corrected in
+this slice, following the 7a precedent where spec-vs-code drift was resolved by ruling on the
+docs.
+
+### A2. The catalogue cannot show stock
+
+The approved prototype renders stock on every card — "In stock", "Low · 3 left", "Sold out" —
+and gives products a `sku`, a `lede` and a `specs` table. The backend serves none of it:
+
+- `GET /products` returns `{id, type, name, price, version}`. `GET /products/:id` adds
+  `attributes`. There is no sku, lede or specs.
+- **Stock lives in Inventory, and the gateway has no `/inventory` mount** — it proxies order,
+  catalog and payment only (`services/gateway/src/app.ts:216-237`). This was confirmed during
+  7d, where it is the reason C4 had to stop `order` to produce gateway-visible errors.
+
+Since the storefront talks only to the gateway (umbrella decision #7), stock is unreachable.
+**8a therefore omits it.** Availability is proven at checkout by the reservation step, which
+is 8b/8c's story. Adding a gateway inventory route or projecting availability into Catalog are
+both real options, and both are backend work that does not belong inside a frontend slice.
+
+## B. Contracts, and preventing drift for real
+
+### B1. Two read DTOs, because there are two shapes
+
+`packages/contracts` currently exports event payloads only — there is no DTO for the read API
+the storefront consumes. 8a adds them:
+
+- `ProductListItem` — `{ id, type, name, price, version }`, what `GET /products` returns.
+- `ProductDetail` — the same plus `attributes`, what `GET /products/:id` returns.
+
+Two schemas, not one with an optional field, because the routes genuinely differ and an
+optional `attributes` would let a detail view silently render nothing when the field goes
+missing.
+
+`type` is the union `ELECTRONICS | CLOTHING | FURNITURE | MOTORBIKE`, verified against
+`services/catalog/src/attributes.ts`.
+
+`attributes` stays `z.record(z.unknown())` at the boundary. Catalog already validates
+type-specific attributes with per-type schemas it owns; restating them in a shared package
+would create a second source of truth to keep in sync, which is the drift this section exists
+to prevent.
+
+`price` is **integer minor units** — "Widget" is `900`, meaning $9.00. Formatting divides by
+100 at the presentation layer and nowhere else.
+
+`GET /products` takes **no parameters**: it is `findMany({ orderBy: { createdAt: "asc" } })`
+with no take or skip, so the whole catalogue arrives in one response. 8a renders all of it.
+Pagination is a Catalog change and is out of scope; the client must not send `?limit=` and
+imply otherwise.
+
+### B2. The client validating alone does not prevent drift
+
+The umbrella's "no contract drift" item is satisfied on paper by importing shared DTOs and
+validating responses. It is not satisfied in practice: if Catalog changes its response shape,
+only the storefront finds out, at runtime, in a browser, as a blank grid.
+
+So the schema is pinned from **both** ends. **Catalog's own integration tests assert its
+responses satisfy the shared schemas.** Drift then fails a backend test in CI, next to the
+change that caused it, instead of surfacing as a frontend bug days later.
+
+This is the only change 8a makes to a service, and it adds assertions to existing tests —
+no production code.
+
+### B3. Schema mismatch is a distinct failure
+
+The client distinguishes three failures because they need three responses:
+
+| Failure | Meaning | Response |
+|---|---|---|
+| Network | Gateway unreachable | Retryable; "try again" affordance |
+| HTTP status | 4xx/5xx from the gateway | Error state with the status |
+| **Schema mismatch** | **Backend drift — a bug** | **Own error type, loud in dev** |
+
+Collapsing the third into a generic error is how a contract violation gets mistaken for an
+empty catalogue. It renders an error, never an empty grid.
+
+## C. The app
+
+### C1. Same-origin, always
+
+The browser never addresses the gateway directly. Vite's dev server proxies `/products` (and
+later `/cart`, `/orders`, `/auth`) to the gateway; the 8c production image will be nginx
+serving the bundle and proxying the same prefixes.
+
+This is load-bearing for three reasons:
+
+1. **The gateway has no CORS middleware at all** — verified: nothing in
+   `services/gateway/src` references cors or `Access-Control`. A cross-origin fetch from
+   `:5173` is simply blocked. Same-origin needs no gateway change.
+2. **8b's cookies work with `SameSite=Lax`.** Cross-origin would force `SameSite=None;
+   Secure`, which does not survive plain `http://localhost` — a trap that would surface only
+   once auth landed.
+3. **The gateway URL never enters the bundle.** It configures the proxy, which is dev-server
+   and nginx config. That satisfies the DoD's "env-based config (Gateway URL)" and its
+   sibling "zero secrets in the bundle" more literally than a `VITE_` variable would.
+
+`/products` is mounted `authOptional`, so the catalogue is genuinely public and 8a needs no
+auth to render it.
+
+### C2. Layers
+
+- **`src/api/`** — one `request()` performing fetch → status mapping → zod parse, plus a
+  module per resource (`products.ts`). The only code that knows HTTP exists. Everything above
+  it receives typed values or typed errors.
+- **`src/routes/`** — `Home` and `Product`.
+- **`src/components/`** — presentational primitives. No fetching.
+
+React Query holds server state. **No global store**: the only client state 8a has is the
+current category filter, and cart state arrives in 8b. Inventing a store now would be
+speculative structure for a need that has not appeared.
+
+### C3. Views
+
+**Home** — hero, category filter chips, product grid. **Product detail** — figure, name,
+price, and the `attributes` map rendered as a key/value table, which is the honest substitute
+for the prototype's invented `specs`.
+
+Every async view has three states, per the DoD: loading (skeletons matching the card
+geometry, not a spinner), error (§B3's taxonomy), and empty (a catalogue with no products is
+a real state, and after 7d's cleanup the dev database can genuinely be near-empty).
+
+## D. Design system
+
+Tokens are lifted **verbatim** from the approved prototype
+(`https://claude.ai/code/artifact/d172bc7c-53ef-4d86-9872-a7e89f2bf48e`) into Tailwind's theme
+as CSS variables — the palette (`--paper #F1F1F4`, `--surface #FFFFFF`, `--ink #1D1D1F`,
+`--muted #6E6E76`, `--line #E8E8ED`), the state colours (`--live #B26A12`, `--ok #2E7D46`,
+`--fail #C0392B`, `--focus #2F73E8`), radii 12/16/24/pill, both shadow levels, and the sans
+and mono stacks. The prototype is the reference and already supplies exact values; there is
+nothing to reinterpret.
+
+**Mono with `tabular-nums` for every datum** — prices, ids, versions — per the design
+language.
+
+**Dark values ship in 8a; the toggle does not.** The prototype supplies a complete dark
+palette, so encoding it in the token layer now is nearly free, whereas retrofitting a token
+layer later is the kind of rework that gets skipped. Media query only in 8a; the toggle is 8c
+polish, alongside the `prefers-reduced-motion` block the prototype also already provides.
+
+**8a is deliberately monochrome.** The design language reserves colour to encode saga state —
+amber in-progress, green confirmed, red cancelled. There is no saga in 8a, and spending those
+three colours on a product grid would burn the encoding before the tracker that needs it
+exists.
+
+Primitives: `Card`, `Badge`, `Price`, `Skeleton`, `EmptyState`, `ErrorState`, `Button`, and
+the four category silhouettes as inline SVG keyed off the `type` union — a 1:1 match with the
+prototype's four.
+
+## E. Testing and CI
+
+`pnpm typecheck` and `pnpm -r build` are recursive, so `apps/web` is covered **automatically**
+once it joins the workspace: CI typechecks it and builds the bundle with no workflow edit.
+
+Tests are the gap. Root `vitest.config.ts` includes only `packages/**`, `services/**` and
+`infra/**`, so `apps/web` tests would silently not run — and they need `jsdom`, which the
+existing node-environment suites must not inherit.
+
+**A `vitest.workspace.ts` with two projects** resolves both: the existing three globs keep
+their current config verbatim, and `apps/web` gets jsdom plus an RTL setup file. One
+`pnpm vitest run` then covers everything, locally and in CI, with no new workflow step.
+
+The rejected alternative is a bespoke `pnpm --filter @ecom/web test` CI step, which leaves
+`pnpm vitest run` quietly missing a project for anyone running it locally. That is precisely
+the silent-gap class that produced 7d's vacuous `pnpm -r typecheck` gate, where the command
+reported "10 of 11 workspace projects" and nobody noticed infra was unchecked.
+
+`eslint.config.js` gains a block for `apps/web`: JSX parsing and `react-hooks` rules.
+Prettier already covers the tree.
+
+**What gets tested**
+
+| Test | Why it can fail |
+|---|---|
+| Boundary rejects a malformed payload | The drift alarm — remove the zod parse and this must fail |
+| Three async states per view | Loading/error/empty are DoD items, not decoration |
+| `Price` formats minor units | `900` must render `$9.00`, never `$900` |
+| `type` → silhouette mapping | All four types resolve; an unknown type degrades, not crashes |
+| Catalog responses satisfy the shared schemas (§B2) | Backend-side drift alarm |
+
+No Playwright — 8c. Whether it runs in CI or locally stays parked, per the roadmap.
+
+## F. Decisions
+
+| # | Decision | Why |
+|---|---|---|
+| 1 | 8a is foundation + catalogue only | The dual-build question and the workspace seam are the risky parts; resolve them before UI volume |
+| 2 | Contracts consumed as source; no dual build | §A1 — the stated premise is false and the alternative regresses eight services |
+| 3 | React 19 | The umbrella says "latest at build time"; Router 7 and Query 5 both support it |
+| 4 | No stock in the catalogue | §A2 — unreachable through the gateway |
+| 5 | Same-origin via proxy, not CORS | §C1 — no backend change, and 8b's cookies work |
+| 6 | Catalog asserts the shared schemas | §B2 — client-only validation does not prevent drift |
+| 7 | `vitest.workspace.ts`, not a bespoke CI step | §E — avoids a silent local gap |
+| 8 | Dark tokens now, toggle in 8c | Free from the prototype; retrofitting a token layer is not |
+| 9 | Monochrome catalogue | Colour is reserved to encode saga state |
+
+## G. Documentation amendments
+
+Three locked statements are contradicted by evidence and are corrected as part of this slice,
+following the 7a precedent (spec-vs-code drift resolved by ruling on the docs).
+
+1. **Umbrella DoD — "`packages/contracts` builds dual ESM+CJS so the ESM/Vite app can import
+   the (CJS) contracts cleanly."** Amended: contracts is consumed as TypeScript source by
+   every consumer in dev and production, as each service's Dockerfile states. `apps/web` does
+   the same through the workspace link.
+2. **Roadmap 8a — "contracts dual ESM+CJS build FIRST, CI-gated."** Amended to workspace
+   wiring. The gate it describes is vacuous because no service's resolution changes.
+3. **Umbrella DoD — "Env-based config (Gateway URL)."** Amended: satisfied at the proxy
+   layer rather than as a bundled `VITE_` variable, which is strictly better against the
+   sibling "zero secrets in the bundle" requirement.
+
+Parked decisions resolved: React 19 (#3), stock deferred (#4). Playwright-in-CI remains
+parked for 8c.
+
+## H. Definition of Done
+
+- [ ] `apps/*` in `pnpm-workspace.yaml`; `apps/web` builds, typechecks and lints via the
+      existing recursive root scripts.
+- [ ] `@ecom/contracts` exports `ProductListItem` and `ProductDetail`; **Catalog's own tests
+      assert its responses satisfy them**.
+- [ ] Every gateway response is zod-validated at the boundary; schema mismatch is a distinct,
+      loud error, never an empty grid.
+- [ ] Home grid and product detail each render loading, error and empty states.
+- [ ] Design tokens match the approved prototype exactly, including dark values.
+- [ ] `pnpm vitest run` covers `apps/web` through `vitest.workspace.ts`, with the existing
+      three projects unchanged.
+- [ ] Browser talks only to same-origin paths; no CORS middleware added to the gateway; no
+      gateway URL in the bundle.
+- [ ] No production code changed in any of the eight services.
+- [ ] Umbrella DoD and roadmap amended per §G.
+
+### Known limitations carried in
+
+- **No pagination.** `GET /products` serves the entire catalogue in one response, so the grid
+  is unbounded. Acceptable at demo scale; a Catalog change if it ever is not.
+- **No stock.** §A2.
+- **No sku / lede / specs.** The prototype invents them; the detail view renders the real
+  `attributes` map instead.
+- **Vite + symlinked TS workspace package** may need `optimizeDeps` or `preserveSymlinks`
+  tuning. Contained to `apps/web`'s config.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,5 +22,13 @@ module.exports = tseslint.config(
     languageOptions: {
       globals: { __ENV: "readonly", __VU: "readonly", __ITER: "readonly" },
     },
+  },
+  {
+    // The storefront runs in a browser with JSX, neither of which the service configs cover.
+    files: ["apps/web/**/*.{ts,tsx}"],
+    languageOptions: {
+      parserOptions: { ecmaFeatures: { jsx: true } },
+      globals: { window: "readonly", document: "readonly", fetch: "readonly" },
+    },
   }
 );

--- a/packages/contracts/src/http/catalog.ts
+++ b/packages/contracts/src/http/catalog.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+// The READ API the storefront consumes, distinct from the event payloads in ../events/catalog.
+// Two schemas because the two routes genuinely differ: the list omits `attributes`. Modelling
+// that as one schema with an optional field would let a detail view silently render nothing
+// when the field goes missing.
+export const ProductTypeSchema = z.enum([
+  "ELECTRONICS",
+  "CLOTHING",
+  "FURNITURE",
+  "MOTORBIKE",
+]);
+export type ProductType = z.infer<typeof ProductTypeSchema>;
+
+export const ProductListItemSchema = z.object({
+  id: z.string(),
+  type: ProductTypeSchema,
+  name: z.string(),
+  // Integer MINOR UNITS. 900 is $9.00. Divide by 100 at the presentation layer only.
+  price: z.number().int(),
+  version: z.number().int(),
+});
+export type ProductListItem = z.infer<typeof ProductListItemSchema>;
+
+// `attributes` stays an open record: Catalog owns per-type attribute validation
+// (services/catalog/src/attributes.ts), and restating it here would create a second source of
+// truth to keep in sync — the exact drift these schemas exist to prevent.
+export const ProductDetailSchema = ProductListItemSchema.extend({
+  attributes: z.record(z.unknown()),
+});
+export type ProductDetail = z.infer<typeof ProductDetailSchema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -5,3 +5,4 @@ export * from "./events/inventory";
 export * from "./events/payment";
 export * from "./events/catalog";
 export * from "./events/identity";
+export * from "./http/catalog";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       react-router:
         specifier: 8.3.0
         version: 8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
     devDependencies:
       '@tailwindcss/vite':
         specifier: 4.3.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,53 @@ importers:
         version: 8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: ^2.1.0
-        version: 2.1.9(@types/node@22.20.1)
+        version: 2.1.9(@types/node@22.20.1)(jsdom@30.0.1(@noble/hashes@1.8.0))(lightningcss@1.33.0)
+
+  apps/web:
+    dependencies:
+      '@ecom/contracts':
+        specifier: workspace:*
+        version: link:../../packages/contracts
+      '@tanstack/react-query':
+        specifier: 5.101.4
+        version: 5.101.4(react@19.2.8)
+      react:
+        specifier: 19.2.8
+        version: 19.2.8
+      react-dom:
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
+      react-router:
+        specifier: 8.3.0
+        version: 8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: 4.3.3
+        version: 4.3.3(vite@8.2.0(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@testing-library/jest-dom':
+        specifier: 7.0.0
+        version: 7.0.0(@testing-library/dom@10.4.1)
+      '@testing-library/react':
+        specifier: 16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@types/react':
+        specifier: ^19.2.0
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.0
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: 6.0.5
+        version: 6.0.5(vite@8.2.0(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      jsdom:
+        specifier: 30.0.1
+        version: 30.0.1(@noble/hashes@1.8.0)
+      tailwindcss:
+        specifier: 4.3.3
+        version: 4.3.3
+      vite:
+        specifier: 8.2.0
+        version: 8.2.0(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/contracts:
     dependencies:
@@ -477,12 +523,84 @@ importers:
 
 packages:
 
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
+
+  '@asamuzakjp/css-color@6.0.5':
+    resolution: {integrity: sha512-mbhpPMmnw/kwW19aRNmSUl1QzLbdGo1SCuE49BT98MNwqF6zaHb3o2owssFc/PEO/4t2UjqtCNwocuDtJornzA==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@8.3.0':
+    resolution: {integrity: sha512-UJLfKXBhrc8i1vH2eJXuYQMwlsLKWFw3O+CPqXSuVEiikeAim3UgrfWX0k4tA/X8cRFM8iZ7OaqBokFGbYusdg==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
     engines: {node: '>=0.1.90'}
 
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.10':
+    resolution: {integrity: sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7':
+    resolution: {integrity: sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
   '@dabh/diagnostics@2.0.8':
     resolution: {integrity: sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==}
+
+  '@emnapi/core@2.0.0-alpha.3':
+    resolution: {integrity: sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==}
+
+  '@emnapi/runtime@2.0.0-alpha.3':
+    resolution: {integrity: sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==}
+
+  '@emnapi/wasi-threads@2.0.1':
+    resolution: {integrity: sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -816,6 +934,15 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
   '@grpc/grpc-js@1.14.4':
     resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
     engines: {node: '>=12.10.0'}
@@ -845,11 +972,31 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
+  '@napi-rs/wasm-runtime@1.2.1':
+    resolution: {integrity: sha512-KjZdi8Q1wh89gsVmghvbrMgWl6ZWmRmHV6wjB7/g4Zf0dyO+hH3neZUtuDNPO00qq5YE5RITVWvrIZKRaAmzGQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
 
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -1051,6 +1198,9 @@ packages:
     resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
     engines: {node: '>=14'}
 
+  '@oxc-project/types@0.142.0':
+    resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
+
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
@@ -1144,6 +1294,97 @@ packages:
     resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
     peerDependencies:
       '@redis/client': ^1.0.0
+
+  '@rolldown/binding-android-arm64@1.2.1':
+    resolution: {integrity: sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.2.1':
+    resolution: {integrity: sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.1':
+    resolution: {integrity: sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.2.1':
+    resolution: {integrity: sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.1':
+    resolution: {integrity: sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.1':
+    resolution: {integrity: sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.1':
+    resolution: {integrity: sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.1':
+    resolution: {integrity: sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.1':
+    resolution: {integrity: sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.1':
+    resolution: {integrity: sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.2.1':
+    resolution: {integrity: sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.2.1':
+    resolution: {integrity: sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.2.1':
+    resolution: {integrity: sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.1':
+    resolution: {integrity: sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.1':
+    resolution: {integrity: sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
     resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
@@ -1276,8 +1517,137 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@tailwindcss/node@4.3.3':
+    resolution: {integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==}
+
+  '@tailwindcss/oxide-android-arm64@4.3.3':
+    resolution: {integrity: sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
+    resolution: {integrity: sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
+    resolution: {integrity: sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
+    resolution: {integrity: sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
+    resolution: {integrity: sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
+    resolution: {integrity: sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
+    resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
+    resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
+    resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
+    resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
+    resolution: {integrity: sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
+    resolution: {integrity: sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.3.3':
+    resolution: {integrity: sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.3.3':
+    resolution: {integrity: sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tanstack/query-core@5.101.4':
+    resolution: {integrity: sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==}
+
+  '@tanstack/react-query@5.101.4':
+    resolution: {integrity: sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==}
+    peerDependencies:
+      react: ^18 || ^19
+
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@7.0.0':
+    resolution: {integrity: sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==}
+    engines: {node: '>=22', npm: '>=6', yarn: '>=1'}
+    peerDependencies:
+      '@testing-library/dom': '>=10 <11'
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
   '@types/amqplib@0.10.8':
     resolution: {integrity: sha512-vtDp8Pk1wsE/AuQ8/Rgtm6KUZYqcnTgNvEHwzCkX8rL7AGsC6zqAfKAAJhUZXFhM/Pp++tbnUHiam/8vVpPztA==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/bcryptjs@2.4.6':
     resolution: {integrity: sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==}
@@ -1343,6 +1713,14 @@ packages:
 
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
   '@types/send@0.17.6':
     resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
@@ -1424,6 +1802,19 @@ packages:
     resolution: {integrity: sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitejs/plugin-react@6.0.5':
+    resolution: {integrity: sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
 
@@ -1482,8 +1873,19 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
@@ -1510,6 +1912,9 @@ packages:
 
   bcryptjs@2.4.3:
     resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   bintrees@1.0.2:
     resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
@@ -1644,6 +2049,9 @@ packages:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
+
   cookie-parser@1.4.7:
     resolution: {integrity: sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==}
     engines: {node: '>= 0.8.0'}
@@ -1669,6 +2077,20 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -1685,6 +2107,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
@@ -1708,6 +2133,10 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
@@ -1715,8 +2144,18 @@ packages:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -1748,6 +2187,14 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  enhanced-resolve@5.24.5:
+    resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
+    engines: {node: '>=10.13.0'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -1993,6 +2440,9 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -2012,6 +2462,10 @@ packages:
   helmet@8.3.0:
     resolution: {integrity: sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==}
     engines: {node: '>=18.0.0'}
+
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -2049,6 +2503,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -2076,6 +2534,9 @@ packages:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
@@ -2087,9 +2548,21 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
+
+  jsdom@30.0.1:
+    resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      canvas: ^3.2.3
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -2123,6 +2596,146 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
+    engines: {node: '>= 12.0.0'}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -2165,12 +2778,23 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -2204,6 +2828,10 @@ packages:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
     engines: {node: '>=4.0.0'}
     hasBin: true
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -2281,6 +2909,9 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -2362,6 +2993,10 @@ packages:
     resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postgres-array@2.0.0:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
     engines: {node: '>=4'}
@@ -2386,6 +3021,10 @@ packages:
     resolution: {integrity: sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==}
     engines: {node: '>=14'}
     hasBin: true
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
   prisma@6.19.3:
     resolution: {integrity: sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==}
@@ -2434,6 +3073,28 @@ packages:
   rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
 
+  react-dom@19.2.8:
+    resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
+    peerDependencies:
+      react: ^19.2.8
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-router@8.3.0:
+    resolution: {integrity: sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==}
+    engines: {node: '>=22.22.0'}
+    peerDependencies:
+      react: '>=19.2.7'
+      react-dom: '>=19.2.7'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
+  react@19.2.8:
+    resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
+    engines: {node: '>=0.10.0'}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
@@ -2442,11 +3103,19 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   redis@4.7.1:
     resolution: {integrity: sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   require-in-the-middle@8.0.1:
@@ -2459,6 +3128,11 @@ packages:
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+
+  rolldown@1.2.1:
+    resolution: {integrity: sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
 
   rollup@4.62.2:
     resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
@@ -2474,6 +3148,13 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
@@ -2550,6 +3231,10 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -2565,6 +3250,16 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tailwindcss@4.3.3:
+    resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
 
   tdigest@0.1.2:
     resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
@@ -2598,6 +3293,13 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.4.9:
+    resolution: {integrity: sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==}
+
+  tldts@7.4.9:
+    resolution: {integrity: sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -2605,6 +3307,14 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   triple-beam@1.4.1:
     resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
@@ -2615,6 +3325,9 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsx@4.23.1:
     resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
@@ -2643,6 +3356,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@8.9.0:
+    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
+    engines: {node: '>=22.19.0'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -2705,6 +3422,49 @@ packages:
       terser:
         optional: true
 
+  vite@8.2.0:
+    resolution: {integrity: sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.4.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vitest@2.1.9:
     resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -2729,6 +3489,26 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@17.1.0:
+    resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
+    engines: {node: ^22.14.0 || >=24.0.0}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -2758,6 +3538,13 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -2792,13 +3579,84 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.5.0': {}
+
+  '@asamuzakjp/css-color@6.0.5':
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/dom-selector@8.3.0':
+    dependencies:
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/runtime@7.29.7': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@colors/colors@1.6.0': {}
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@dabh/diagnostics@2.0.8':
     dependencies:
       '@so-ric/colorspace': 1.1.6
       enabled: 2.0.0
       kuler: 2.0.0
+
+  '@emnapi/core@2.0.0-alpha.3':
+    dependencies:
+      '@emnapi/wasi-threads': 2.0.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@2.0.0-alpha.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@2.0.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -2993,6 +3851,10 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@exodus/bytes@1.15.1(@noble/hashes@1.8.0)':
+    optionalDependencies:
+      '@noble/hashes': 1.8.0
+
   '@grpc/grpc-js@1.14.4':
     dependencies:
       '@grpc/proto-loader': 0.8.1
@@ -3021,9 +3883,33 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   '@js-sdsl/ordered-map@4.4.2': {}
+
+  '@napi-rs/wasm-runtime@1.2.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
+    dependencies:
+      '@emnapi/core': 2.0.0-alpha.3
+      '@emnapi/runtime': 2.0.0-alpha.3
+      '@tybys/wasm-util': 0.10.3
+    optional: true
 
   '@noble/hashes@1.8.0': {}
 
@@ -3281,6 +4167,8 @@ snapshots:
 
   '@opentelemetry/semantic-conventions@1.43.0': {}
 
+  '@oxc-project/types@0.142.0': {}
+
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
       '@noble/hashes': 1.8.0
@@ -3373,6 +4261,57 @@ snapshots:
     dependencies:
       '@redis/client': 1.6.1
 
+  '@rolldown/binding-android-arm64@1.2.1':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.1':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.1':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.1':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.1':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.1':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.1':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.2.1':
+    dependencies:
+      '@emnapi/core': 2.0.0-alpha.3
+      '@emnapi/runtime': 2.0.0-alpha.3
+      '@napi-rs/wasm-runtime': 1.2.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.1':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.1':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@rollup/rollup-android-arm-eabi@4.62.2':
     optional: true
 
@@ -3455,9 +4394,122 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@tailwindcss/node@4.3.3':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.24.5
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.3
+
+  '@tailwindcss/oxide-android-arm64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide@4.3.3':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-x64': 4.3.3
+      '@tailwindcss/oxide-freebsd-x64': 4.3.3
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.3
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.3
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.3
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
+
+  '@tailwindcss/vite@4.3.3(vite@8.2.0(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.3
+      '@tailwindcss/oxide': 4.3.3
+      tailwindcss: 4.3.3
+      vite: 8.2.0(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+
+  '@tanstack/query-core@5.101.4': {}
+
+  '@tanstack/react-query@5.101.4(react@19.2.8)':
+    dependencies:
+      '@tanstack/query-core': 5.101.4
+      react: 19.2.8
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      '@testing-library/dom': 10.4.1
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@types/amqplib@0.10.8':
     dependencies:
       '@types/node': 22.20.1
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/bcryptjs@2.4.6': {}
 
@@ -3532,6 +4584,14 @@ snapshots:
   '@types/qs@6.15.1': {}
 
   '@types/range-parser@1.2.7': {}
+
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
+  '@types/react@19.2.17':
+    dependencies:
+      csstype: 3.2.3
 
   '@types/send@0.17.6':
     dependencies:
@@ -3655,6 +4715,11 @@ snapshots:
       '@typescript-eslint/types': 8.64.0
       eslint-visitor-keys: 5.0.1
 
+  '@vitejs/plugin-react@6.0.5(vite@8.2.0(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.2.0(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+
   '@vitest/expect@2.1.9':
     dependencies:
       '@vitest/spy': 2.1.9
@@ -3662,13 +4727,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.20.1))':
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.20.1)(lightningcss@1.33.0))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 5.4.21(@types/node@22.20.1)
+      vite: 5.4.21(@types/node@22.20.1)(lightningcss@1.33.0)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -3724,7 +4789,15 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
 
   array-flatten@1.1.1: {}
 
@@ -3741,6 +4814,10 @@ snapshots:
   balanced-match@4.0.4: {}
 
   bcryptjs@2.4.3: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   bintrees@1.0.2: {}
 
@@ -3883,6 +4960,8 @@ snapshots:
 
   content-type@1.0.5: {}
 
+  cookie-es@3.1.1: {}
+
   cookie-parser@1.4.7:
     dependencies:
       cookie: 0.7.2
@@ -3904,6 +4983,22 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
+
+  csstype@3.2.3: {}
+
+  data-urls@7.0.0(@noble/hashes@1.8.0):
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
@@ -3911,6 +5006,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   deep-eql@5.0.2: {}
 
@@ -3924,14 +5021,22 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dequal@2.0.3: {}
+
   destr@2.0.5: {}
 
   destroy@1.2.0: {}
+
+  detect-libc@2.1.2: {}
 
   dezalgo@1.0.4:
     dependencies:
       asap: 2.0.6
       wrappy: 1.0.2
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dotenv@16.6.1: {}
 
@@ -3959,6 +5064,13 @@ snapshots:
   enabled@2.0.0: {}
 
   encodeurl@2.0.0: {}
+
+  enhanced-resolve@5.24.5:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
+  entities@8.0.0: {}
 
   es-define-property@1.0.1: {}
 
@@ -4286,6 +5398,8 @@ snapshots:
 
   gopd@1.2.0: {}
 
+  graceful-fs@4.2.11: {}
+
   has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
@@ -4299,6 +5413,12 @@ snapshots:
       function-bind: 1.1.2
 
   helmet@8.3.0: {}
+
+  html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   http-errors@2.0.1:
     dependencies:
@@ -4348,6 +5468,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@4.0.0: {}
+
   inherits@2.0.4: {}
 
   ipaddr.js@1.9.1: {}
@@ -4364,15 +5486,45 @@ snapshots:
 
   is-plain-object@5.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-stream@2.0.1: {}
 
   isexe@2.0.0: {}
 
   jiti@2.7.0: {}
 
+  js-tokens@4.0.0: {}
+
   js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@30.0.1(@noble/hashes@1.8.0):
+    dependencies:
+      '@asamuzakjp/css-color': 6.0.5
+      '@asamuzakjp/dom-selector': 8.3.0
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.7(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1(@noble/hashes@1.8.0)
+      css-tree: 3.2.1
+      data-urls: 7.0.0(@noble/hashes@1.8.0)
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 8.9.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 17.1.0(@noble/hashes@1.8.0)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   json-buffer@3.0.1: {}
 
@@ -4417,6 +5569,104 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -4452,11 +5702,17 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@11.5.2: {}
+
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   media-typer@0.3.0: {}
 
@@ -4478,6 +5734,8 @@ snapshots:
   mime@1.6.0: {}
 
   mime@2.6.0: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -4548,6 +5806,10 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   parseurl@1.3.3: {}
 
   path-exists@4.0.0: {}
@@ -4617,6 +5879,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postcss@8.5.25:
+    dependencies:
+      nanoid: 3.3.16
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   postgres-array@2.0.0: {}
 
   postgres-bytea@1.0.1: {}
@@ -4630,6 +5898,12 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   prettier@3.9.5: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   prisma@6.19.3(typescript@5.9.3):
     dependencies:
@@ -4689,6 +5963,22 @@ snapshots:
       defu: 6.1.7
       destr: 2.0.5
 
+  react-dom@19.2.8(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      scheduler: 0.27.0
+
+  react-is@17.0.2: {}
+
+  react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      cookie-es: 3.1.1
+      react: 19.2.8
+    optionalDependencies:
+      react-dom: 19.2.8(react@19.2.8)
+
+  react@19.2.8: {}
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
@@ -4696,6 +5986,11 @@ snapshots:
       util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   redis@4.7.1:
     dependencies:
@@ -4708,6 +6003,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   require-in-the-middle@8.0.1:
     dependencies:
       debug: 4.4.3
@@ -4718,6 +6015,27 @@ snapshots:
   requires-port@1.0.0: {}
 
   resolve-from@4.0.0: {}
+
+  rolldown@1.2.1:
+    dependencies:
+      '@oxc-project/types': 0.142.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.1
+      '@rolldown/binding-darwin-arm64': 1.2.1
+      '@rolldown/binding-darwin-x64': 1.2.1
+      '@rolldown/binding-freebsd-x64': 1.2.1
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.1
+      '@rolldown/binding-linux-arm64-gnu': 1.2.1
+      '@rolldown/binding-linux-arm64-musl': 1.2.1
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.1
+      '@rolldown/binding-linux-s390x-gnu': 1.2.1
+      '@rolldown/binding-linux-x64-gnu': 1.2.1
+      '@rolldown/binding-linux-x64-musl': 1.2.1
+      '@rolldown/binding-openharmony-arm64': 1.2.1
+      '@rolldown/binding-wasm32-wasi': 1.2.1
+      '@rolldown/binding-win32-arm64-msvc': 1.2.1
+      '@rolldown/binding-win32-x64-msvc': 1.2.1
 
   rollup@4.62.2:
     dependencies:
@@ -4755,6 +6073,12 @@ snapshots:
   safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
+  scheduler@0.27.0: {}
 
   semver@7.8.5: {}
 
@@ -4849,6 +6173,10 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@3.1.1: {}
 
   superagent@10.3.0:
@@ -4877,6 +6205,12 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  symbol-tree@3.2.4: {}
+
+  tailwindcss@4.3.3: {}
+
+  tapable@2.3.3: {}
+
   tdigest@0.1.2:
     dependencies:
       bintrees: 1.0.2
@@ -4900,17 +6234,34 @@ snapshots:
 
   tinyspy@3.0.2: {}
 
+  tldts-core@7.4.9: {}
+
+  tldts@7.4.9:
+    dependencies:
+      tldts-core: 7.4.9
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
 
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.9
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
+
   triple-beam@1.4.1: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  tslib@2.8.1:
+    optional: true
 
   tsx@4.23.1:
     dependencies:
@@ -4942,6 +6293,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici@8.9.0: {}
+
   unpipe@1.0.0: {}
 
   uri-js@4.4.1:
@@ -4961,13 +6314,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@2.1.9(@types/node@22.20.1):
+  vite-node@2.1.9(@types/node@22.20.1)(lightningcss@1.33.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 1.1.2
-      vite: 5.4.21(@types/node@22.20.1)
+      vite: 5.4.21(@types/node@22.20.1)(lightningcss@1.33.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -4979,7 +6332,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.21(@types/node@22.20.1):
+  vite@5.4.21(@types/node@22.20.1)(lightningcss@1.33.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.19
@@ -4987,11 +6340,27 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.20.1
       fsevents: 2.3.3
+      lightningcss: 1.33.0
 
-  vitest@2.1.9(@types/node@22.20.1):
+  vite@8.2.0(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.25
+      rolldown: 1.2.1
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.20.1
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.23.1
+      yaml: 2.9.0
+
+  vitest@2.1.9(@types/node@22.20.1)(jsdom@30.0.1(@noble/hashes@1.8.0))(lightningcss@1.33.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.20.1))
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.20.1)(lightningcss@1.33.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -5007,11 +6376,12 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
-      vite: 5.4.21(@types/node@22.20.1)
-      vite-node: 2.1.9(@types/node@22.20.1)
+      vite: 5.4.21(@types/node@22.20.1)(lightningcss@1.33.0)
+      vite-node: 2.1.9(@types/node@22.20.1)(lightningcss@1.33.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.20.1
+      jsdom: 30.0.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -5022,6 +6392,30 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1(@noble/hashes@1.8.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@1.8.0)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@17.1.0(@noble/hashes@1.8.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@1.8.0)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which@2.0.2:
     dependencies:
@@ -5061,6 +6455,10 @@ snapshots:
       strip-ansi: 6.0.1
 
   wrappy@1.0.2: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - "packages/*"
   - "services/*"
+  - "apps/*"
 
 # pnpm 10 blocks dependency build scripts by default. Allow the ones we need:
 # prisma engines (query engine binary) and esbuild (backs tsx at runtime).

--- a/services/catalog/src/__tests__/product-contract.int.test.ts
+++ b/services/catalog/src/__tests__/product-contract.int.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, afterAll } from "vitest";
+import request from "supertest";
+import { createApp } from "../app";
+import { prisma } from "../db";
+import { ProductListItemSchema, ProductDetailSchema } from "@ecom/contracts";
+
+const app = createApp();
+
+// Catalog asserting its OWN responses against the shared schemas is what makes the storefront
+// safe. A client that only validates on its side discovers drift at runtime, in a browser, as
+// a blank grid. Here, drift fails a backend test next to the change that caused it.
+const TEST_TAG = "test-catalog-contract-int";
+
+describe("catalog read API satisfies the shared contracts", () => {
+  afterAll(async () => {
+    const seeded = await prisma.product.findMany({
+      where: { name: { startsWith: TEST_TAG } },
+      select: { id: true },
+    });
+    const ids = seeded.map((p) => p.id);
+    if (ids.length > 0) {
+      await prisma.outbox.deleteMany({ where: { aggregateId: { in: ids } } });
+      await prisma.product.deleteMany({ where: { id: { in: ids } } });
+    }
+    await prisma.$disconnect();
+  });
+
+  it("GET /products items satisfy ProductListItemSchema", async () => {
+    await request(app)
+      .post("/products")
+      .send({
+        type: "ELECTRONICS",
+        name: `${TEST_TAG}-list`,
+        price: 900,
+        attributes: { manufacturer: "Acme" },
+      })
+      .expect(201);
+
+    const res = await request(app).get("/products").expect(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThan(0);
+    for (const item of res.body) {
+      const parsed = ProductListItemSchema.safeParse(item);
+      if (!parsed.success) throw new Error(`list item drifted: ${parsed.error.message}`);
+    }
+  });
+
+  it("GET /products/:id satisfies ProductDetailSchema, including attributes", async () => {
+    const created = await request(app)
+      .post("/products")
+      .send({
+        type: "CLOTHING",
+        name: `${TEST_TAG}-detail`,
+        price: 2450,
+        attributes: { brand: "Acme", size: "M", material: "cotton", color: "blue" },
+      })
+      .expect(201);
+
+    const res = await request(app).get(`/products/${created.body.productId}`).expect(200);
+    const parsed = ProductDetailSchema.safeParse(res.body);
+    if (!parsed.success) throw new Error(`detail drifted: ${parsed.error.message}`);
+    expect(parsed.data.attributes).toMatchObject({ brand: "Acme" });
+    expect(parsed.data.price).toBe(2450);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,0 @@
-import { defineConfig } from "vitest/config";
-
-export default defineConfig({
-  test: {
-    include: ["packages/**/*.test.ts", "services/**/*.test.ts", "infra/**/*.test.ts"],
-    testTimeout: 20_000,
-    hookTimeout: 30_000,
-  },
-});

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,16 @@
+// One `pnpm vitest run` covers every project. The three node projects keep the globs and
+// timeouts the root config already used; apps/web needs jsdom, which the node projects must
+// not inherit — which is the whole reason this file exists.
+import { defineWorkspace } from "vitest/config";
+
+const node = {
+  testTimeout: 20_000,
+  hookTimeout: 30_000,
+};
+
+export default defineWorkspace([
+  { test: { ...node, name: "packages", include: ["packages/**/*.test.ts"] } },
+  { test: { ...node, name: "services", include: ["services/**/*.test.ts"] } },
+  { test: { ...node, name: "infra", include: ["infra/**/*.test.ts"] } },
+  "./apps/web",
+]);


### PR DESCRIPTION
Stands up `apps/web` — a Vite + React storefront in the pnpm workspace — rendering Catalog's product list and detail through the gateway, with every response validated at the boundary against schemas Catalog itself is tested against.

Spec: `docs/superpowers/specs/2026-07-30-phase-8a-storefront-foundation-design.md`
Plan: `docs/superpowers/plans/2026-07-30-phase-8a-storefront-foundation.md`

## What shipped

The app joins the workspace and imports `@ecom/contracts` as **TypeScript source**, exactly as the eight services do — the dual ESM+CJS build the roadmap opened 8a with is withdrawn, because nothing in the repo imports `contracts/dist` and Vite was verified to resolve the source before any feature depended on it.

The browser never addresses the gateway. It calls same-origin `/api/*`, which the dev proxy strips — no CORS on the gateway, no gateway host in the bundle, and 8b's cookies will work on `SameSite=Lax`.

One `request()` owns fetch, status mapping and zod parsing, and is the only module that knows HTTP exists. It raises three distinct errors, because the three failures deserve three responses: a dropped connection is worth retrying, a 404 is a product that will never exist, and a schema mismatch is a bug. The React Query retry policy is pinned to match — network only, bounded — since the default of three retries on everything would hammer the gateway over a 404 and delay a drift bug by three round trips.

Drift is caught on the **backend**: Catalog asserts its own responses against the shared schemas, so a field rename fails a test beside the change that caused it rather than surfacing in a browser as a blank grid.

## Gates

| Gate | Result |
|---|---|
| `pnpm typecheck` | exit 0 |
| `pnpm format:check` | exit 0 |
| `pnpm lint` | 0 errors (10 pre-existing warnings in service tests) |
| `pnpm -r build` | green; `apps/web/dist` produced |
| `@ecom/web` | 27 passed / 6 files |
| `packages` | 144 passed / 38 files |
| Catalog contract test | 2 passed against live Postgres |
| Real-stack acceptance | run in a browser — see below |

**Acceptance against the running stack:** 268 real products in the grid; requests hit `localhost:5173/api/products`, not `:8000` — proof the proxy carries them and no CORS is involved; a card navigates to detail with real attributes; a hard navigation straight to a product URL renders the app; `/products/nope` renders "Product not found".

**Known-failing, not caused by this branch:** `--project infra` fails on `INV1_ORDER_TERMINAL`, `INV3_RESERVATION_SPLIT` and `DRAIN_TIMEOUT` against the local databases. 7d's merge record already records that suite as environment-bound ("requires the relays stopped"); measured both ways here, stopping the relays fixes the INV4 test exactly as predicted, and the rest is stale saga state from 2026-07-30. This branch changed exactly one file under `services/`+`infra/` — a new test — and never creates an order or a reservation.

## Deviations

Ten, in full in `.scratch/phase-8a/impl-notes.html`. The three that changed the design:

**D9 — the API moved under `/api/*` (spec-level).** The spec proxied `/products` at the origin root while the plan mounted the storefront's page at `/products/:id`. Those are the same URL and the proxy answers first, so a hard refresh or a shared product link returned raw JSON instead of the app — verified in a browser before changing anything. Only client-side navigation worked, which is why the entire jsdom suite passed. 8b widens it, since `/cart` and `/orders` are storefront pages too. The spec's §C1 rationale is untouched — still same-origin, still no CORS, still no gateway URL in the bundle — only the prefix changes, and 8c's nginx gets one location block instead of one per prefix. Three tests pin the paths; all three fail if the prefix is dropped.

**D5/D6/D7 — three Tailwind v4 assumptions, each failing silently.** `@theme` nested in a media query is hoisted, so the dark palette was not conditional — it overwrote light, and the light palette left the bundle entirely; the app would have shipped permanently dark. `@theme` is also tree-shaken, and arbitrary values like `text-[color:var(--color-muted)]` do not count as references, so 2 of 15 colours were being emitted. And v4 dropped the `-DEFAULT` convention — bare `rounded` is a static `0.25rem` reading no variable, so buttons would have rendered 4px corners beside 24px cards. All three were established against the built CSS, not assumed.

**D1 — the vite and vitest configs had to split.** vitest 2.1 declares its types against vite 5.4.21 while this app pins vite 8.2.0; both pins are deliberate (Global Constraints 3 and 5), so a single config typechecks under neither signature. Side benefit: vitest no longer loads vite-8 plugins into its vite-5 runtime.

Also: `zod` declared as a direct dependency (pnpm's strict layout would not have resolved it transitively), the lockfile committed, a fetch spy typed so its call tuple compiles, `MemoryRouter` added to the Home tests, and two more roadmap amendments than the plan listed — its risk register and cross-phase table still scheduled the withdrawn dual build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
