### PR TITLE
Phase 8c — order-pipeline tracker, history and packaging

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,5 @@ pnpm-lock.yaml
 CLAUDE.md
 .github
 docker-compose*.yml
+apps/web/test-results
+apps/web/playwright-report

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,0 +1,3 @@
+e2e/.auth/
+test-results/
+playwright-report/

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1
+FROM node:22-alpine AS build
+RUN corepack enable
+WORKDIR /repo
+
+# Unlike every service image — which runs TypeScript directly through tsx and deliberately has
+# NO build step — the storefront is a real Vite build: the browser receives static assets, not
+# source. @ecom/contracts still comes in as TypeScript source, exactly as the services consume
+# it, so Vite resolves it through its `main: src/index.ts`.
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml tsconfig.base.json ./
+COPY packages ./packages
+COPY apps/web ./apps/web
+RUN pnpm install --frozen-lockfile
+RUN pnpm --filter @ecom/web build
+
+FROM nginx:alpine AS runtime
+COPY --from=build /repo/apps/web/dist /usr/share/nginx/html
+COPY apps/web/nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80

--- a/apps/web/e2e/a11y.spec.ts
+++ b/apps/web/e2e/a11y.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from "@playwright/test";
+
+// These two checks exist against the SHIPPED stylesheet, not against source, because that is
+// where 8a's Tailwind traps lived: a @theme block hoisted out of its media query, and colours
+// tree-shaken away because arbitrary values did not count as references. Every jsdom test in
+// the repo passed over both.
+
+test("the pulse stops under prefers-reduced-motion", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.goto("/");
+
+  const animation = await page.evaluate(() => {
+    const probe = document.createElement("div");
+    probe.className = "tracker-pulse";
+    document.body.append(probe);
+    const name = getComputedStyle(probe).animationName;
+    probe.remove();
+    return name;
+  });
+  expect(animation).toBe("none");
+});
+
+test("the pulse runs when motion is allowed", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "no-preference" });
+  await page.goto("/");
+
+  const animation = await page.evaluate(() => {
+    const probe = document.createElement("div");
+    probe.className = "tracker-pulse";
+    document.body.append(probe);
+    const name = getComputedStyle(probe).animationName;
+    probe.remove();
+    return name;
+  });
+  // Proves the reduced-motion assertion above is measuring something, rather than passing
+  // because the rule was never emitted at all.
+  expect(animation).toBe("tracker-pulse");
+});
+
+test("the first tab stop is the skip link, and focus is visible", async ({ page }) => {
+  await page.goto("/");
+  await page.keyboard.press("Tab");
+
+  const focused = page.locator(":focus");
+  await expect(focused).toHaveText(/skip to content/i);
+
+  const outline = await focused.evaluate((el) => getComputedStyle(el).outlineStyle);
+  expect(outline).not.toBe("none");
+});

--- a/apps/web/e2e/auth.setup.ts
+++ b/apps/web/e2e/auth.setup.ts
@@ -1,0 +1,27 @@
+import { test as setup, expect } from "@playwright/test";
+import { STORAGE_STATE } from "./fixtures";
+
+// One account for the whole run, saved as storage state.
+//
+// The gateway rate-limits /auth/* to 10 requests a minute per apparent client and buckets by
+// the forwarded address (services/gateway/src/app.ts). A browser cannot rotate x-forwarded-for
+// the way infra/scripts/drive-checkouts.ts does, so a suite that registered and signed in per
+// walk would spend its whole budget on authentication and then fail with 429s that read as
+// application bugs. Registering once costs two.
+setup("register and sign in once", async ({ page }) => {
+  const email = `e2e-${Date.now()}@example.test`;
+
+  await page.goto("/register");
+  await page.getByLabel(/name/i).fill("E2E");
+  await page.getByLabel(/email/i).fill(email);
+  await page.getByLabel(/password/i).fill("password123");
+  await page.getByRole("button", { name: /create account/i }).click();
+
+  // Registering does not sign you in (8b §B3): it lands on the login form, email prefilled.
+  await expect(page).toHaveURL(/\/login/);
+  await page.getByLabel(/password/i).fill("password123");
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await expect(page.getByRole("link", { name: /^orders$/i })).toBeVisible();
+
+  await page.context().storageState({ path: STORAGE_STATE });
+});

--- a/apps/web/e2e/checkout.spec.ts
+++ b/apps/web/e2e/checkout.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "@playwright/test";
+import { addSeededProductToCart, seedProduct, SETTLING_PRICE } from "./fixtures";
+
+test("browse to checkout, and the pipeline confirms without a reload", async ({
+  page,
+}) => {
+  const productId = await seedProduct(SETTLING_PRICE, "e2e-settle");
+  await addSeededProductToCart(page, productId);
+
+  // Reaching CONFIRMED is not by itself proof of liveness — the ladder's polling fallback would
+  // get there too, just slower, and a suite that cannot tell them apart would go green over a
+  // completely dead stream. Count both transports and assert which one did the work.
+  let streams = 0;
+  let orderGets = 0;
+  page.on("request", (r) => {
+    if (/\/api\/orders\/[\w-]+\/stream$/.test(r.url())) streams += 1;
+    else if (/\/api\/orders\/[\w-]+$/.test(r.url())) orderGets += 1;
+  });
+
+  await page.goto("/cart");
+  await page.getByRole("button", { name: /place order/i }).click();
+
+  // The order page is reached by the checkout itself, and from here on NOTHING reloads: every
+  // assertion below has to be satisfied by frames arriving over the stream. That is the whole
+  // point of the walk — a green jsdom suite proved liveness in 8a and 7c and was wrong twice.
+  await expect(page).toHaveURL(/\/orders\/[\w-]+/);
+  await expect(page.getByText("Order placed")).toBeVisible();
+
+  await expect(page.getByText("CONFIRMED", { exact: true })).toBeVisible({
+    timeout: 60_000,
+  });
+  // No step is still in flight. Written as an attribute locator on purpose: Playwright's
+  // getByRole has no `current` option (Testing Library does), so passing one is silently
+  // ignored and the assertion would match every list item on the page.
+  await expect(page.locator('li[aria-current="step"]')).toHaveCount(0);
+
+  expect(streams).toBe(1);
+  // One GET for the initial load. More than that would mean the query was polling, i.e. the
+  // stream had failed and the page reached CONFIRMED the slow way.
+  expect(orderGets).toBe(1);
+});
+
+test("the order appears in history", async ({ page }) => {
+  const productId = await seedProduct(SETTLING_PRICE, "e2e-history");
+  await addSeededProductToCart(page, productId);
+  await page.goto("/cart");
+  await page.getByRole("button", { name: /place order/i }).click();
+  await expect(page).toHaveURL(/\/orders\/[\w-]+/);
+  const orderId = page.url().split("/").pop()!;
+
+  await page.getByRole("link", { name: /^orders$/i }).click();
+  await expect(page.getByRole("link", { name: new RegExp(orderId) })).toBeVisible();
+});

--- a/apps/web/e2e/compensation.spec.ts
+++ b/apps/web/e2e/compensation.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "@playwright/test";
+import { addSeededProductToCart, DECLINING_PRICE, seedProduct } from "./fixtures";
+
+// The compensation path is the half of the saga that a happy-path demo never shows: payment
+// declines, Order cancels, Inventory releases the reservation. The tracker has to say so.
+test("a declined payment shows the compensation path", async ({ page }) => {
+  const productId = await seedProduct(DECLINING_PRICE, "e2e-decline");
+  await addSeededProductToCart(page, productId);
+
+  await page.goto("/cart");
+  await page.getByRole("button", { name: /place order/i }).click();
+  await expect(page).toHaveURL(/\/orders\/[\w-]+/);
+
+  // `exact` because the polite live region also says "Order cancelled — Payment failed", and a
+  // substring match would resolve to both it and the badge.
+  await expect(page.getByText("CANCELLED", { exact: true })).toBeVisible({
+    timeout: 60_000,
+  });
+
+  // Observed live, so the tracker knows WHICH leg failed: the reservation succeeded (the order
+  // reached AWAITING_PAYMENT) and the charge did not.
+  // Substring, not an anchored pattern: each step's text starts with its glyph, so ^Payment
+  // matches nothing. "Payment" appears in exactly one of the four step labels.
+  const paymentStep = page.getByRole("listitem").filter({ hasText: "Payment" });
+  await expect(paymentStep).toContainText(/failed/i);
+});

--- a/apps/web/e2e/fixtures.ts
+++ b/apps/web/e2e/fixtures.ts
@@ -41,7 +41,40 @@ export async function seedProduct(price: number, tag: string): Promise<string> {
   });
   if (!stock.ok) throw new Error(`stock seed failed: ${stock.status}`);
 
+  await waitForOrderProjection(productId);
   return productId;
+}
+
+// Order prices an order from its OWN read model, which Catalog feeds asynchronously over
+// Kafka. Placing an order before that projection lands answers 422 "unpriced" — correct
+// behaviour, and a real property of the system, but it makes a walk that checks out
+// immediately after seeding fail perhaps half the time. Waiting on the projection is the
+// difference between a suite that tests the storefront and one that tests a race.
+async function waitForOrderProjection(
+  productId: string,
+  timeoutMs = 20_000
+): Promise<void> {
+  const { Client } = await import("pg");
+  const client = new Client({
+    connectionString:
+      process.env.ORDER_DB_URL ?? "postgres://ecom:ecom@localhost:5432/order",
+  });
+  await client.connect();
+  try {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      const r = await client.query(
+        'SELECT 1 FROM "CatalogReadModel" WHERE "productId" = $1',
+        [productId]
+      );
+      if (r.rowCount && r.rowCount > 0) return;
+      if (Date.now() > deadline)
+        throw new Error(`catalog projection never reached Order for ${productId}`);
+      await new Promise((r) => setTimeout(r, 250));
+    }
+  } finally {
+    await client.end();
+  }
 }
 
 export async function addSeededProductToCart(

--- a/apps/web/e2e/fixtures.ts
+++ b/apps/web/e2e/fixtures.ts
@@ -1,0 +1,54 @@
+import { expect, type Page } from "@playwright/test";
+
+// Written by the setup project, read by every walk. Gitignored: it holds a live session.
+export const STORAGE_STATE = "e2e/.auth/user.json";
+
+// Catalog and Inventory are addressed DIRECTLY, not through the gateway. Creating a product is
+// an ADMIN-granted mutation and Inventory is not mounted on the gateway at all, so a fixture
+// that went through the front door would need an admin session the storefront never has. These
+// are dev-published ports; nothing in the app knows they exist.
+const CATALOG = process.env.CATALOG_URL ?? "http://localhost:3004";
+const INVENTORY = process.env.INVENTORY_URL ?? "http://localhost:3001";
+
+// Payment declines when the charged minor units satisfy % 100 === 1 and parks in PROCESSING
+// when they satisfy % 100 === 99 (services/payment/src/charge.ts). The storefront cannot pick
+// an amount — the total comes from catalog prices through Order's read model — so a walk that
+// needs a decline has to create a product priced to land there. 99 is avoided deliberately:
+// that is the async webhook path, which never settles on its own.
+export const DECLINING_PRICE = 1301;
+export const SETTLING_PRICE = 1300;
+
+export async function seedProduct(price: number, tag: string): Promise<string> {
+  const res = await fetch(`${CATALOG}/products`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      type: "ELECTRONICS",
+      name: `${tag}-${Date.now()}`,
+      price,
+      attributes: { manufacturer: "e2e", model: tag },
+    }),
+  });
+  if (!res.ok) throw new Error(`product create failed: ${res.status}`);
+  const { productId } = (await res.json()) as { productId: string };
+
+  // Without stock the saga cancels at the reservation leg, so every walk would take the
+  // compensation path and the confirming one would fail for the wrong reason.
+  const stock = await fetch(`${INVENTORY}/inventory/stock`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ productId, quantity: 50 }),
+  });
+  if (!stock.ok) throw new Error(`stock seed failed: ${stock.status}`);
+
+  return productId;
+}
+
+export async function addSeededProductToCart(
+  page: Page,
+  productId: string
+): Promise<void> {
+  await page.goto(`/products/${productId}`);
+  await page.getByRole("button", { name: /add to cart/i }).click();
+  await expect(page.getByRole("link", { name: /cart \(/i })).toContainText("1");
+}

--- a/apps/web/e2e/session-expiry.spec.ts
+++ b/apps/web/e2e/session-expiry.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+import { addSeededProductToCart, seedProduct, SETTLING_PRICE } from "./fixtures";
+
+// 8b deferred this walk, and 8c is where it belongs: the ladder's first rung exists precisely
+// for an access token that dies mid-saga. Dropping only the access cookie leaves the refresh
+// cookie in place, which is the real shape of an expiry — the session is recoverable, and the
+// page must recover it rather than stranding the user on a tracker that stopped moving.
+test("a session expiring mid-saga still reaches a terminal state", async ({
+  page,
+  context,
+}) => {
+  const productId = await seedProduct(SETTLING_PRICE, "e2e-expiry");
+  await addSeededProductToCart(page, productId);
+
+  await page.goto("/cart");
+  await page.getByRole("button", { name: /place order/i }).click();
+  await expect(page).toHaveURL(/\/orders\/[\w-]+/);
+
+  // Kill the access token while the saga is in flight, keeping the refresh token.
+  const kept = (await context.cookies()).filter((c) => c.name !== "access_token");
+  await context.clearCookies();
+  await context.addCookies(kept);
+
+  await expect(page.getByText(/CONFIRMED|CANCELLED/)).toBeVisible({ timeout: 60_000 });
+  // Recovered, not signed out: a redirect to /login would mean the ladder gave up on a session
+  // that was still refreshable.
+  await expect(page).toHaveURL(/\/orders\/[\w-]+/);
+});

--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -1,0 +1,33 @@
+server {
+  listen 80;
+  server_name _;
+  root /usr/share/nginx/html;
+
+  # A deep link like /orders/abc is a client route, not a file on disk. Without this, a hard
+  # refresh or a shared order link 404s where client-side navigation worked — the same class of
+  # bug 8a hit with the API prefix, and equally invisible to a jsdom suite.
+  location / {
+    try_files $uri /index.html;
+  }
+
+  # One location block, because the browser addresses everything the gateway serves under a
+  # single /api prefix. The trailing slash on proxy_pass is what strips it.
+  location /api/ {
+    proxy_pass http://gateway:8000/;
+    proxy_http_version 1.1;
+
+    # LOAD-BEARING. With buffering on, nginx accumulates the SSE stream and releases it in
+    # chunks, so the tracker sits motionless while the backend works perfectly — a backend
+    # success that reads as a frontend bug, and one that only appears in this packaged shape.
+    proxy_buffering off;
+    proxy_cache off;
+
+    # Must outlive an idle stream between the order service's 15s heartbeats.
+    proxy_read_timeout 1h;
+
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -p tsconfig.json --noEmit && vite build",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "e2e": "playwright test"
   },
   "dependencies": {
     "@ecom/contracts": "workspace:*",
@@ -18,6 +19,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@tailwindcss/vite": "4.3.3",
     "@testing-library/jest-dom": "7.0.0",
     "@testing-library/react": "16.3.2",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,10 +23,12 @@
     "@tailwindcss/vite": "4.3.3",
     "@testing-library/jest-dom": "7.0.0",
     "@testing-library/react": "16.3.2",
+    "@types/pg": "^8.20.0",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
     "@vitejs/plugin-react": "6.0.5",
     "jsdom": "30.0.1",
+    "pg": "^8.22.0",
     "tailwindcss": "4.3.3",
     "vite": "8.2.0"
   }

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig } from "@playwright/test";
+
+// LOCAL ONLY. CI's quality job has no compose stack, and standing up eight services plus two
+// brokers to run three browser walks is its own slice — see the 8c spec §F4, where the absence
+// is recorded as a decision rather than a gap.
+//
+// Prerequisites: `docker compose up -d` (datastores AND the app profile), then either the Vite
+// dev server or the nginx image from apps/web/Dockerfile. Point WEB_URL at whichever is up.
+export default defineConfig({
+  testDir: "./e2e",
+  // A walk waits on a real saga: Kafka hop, outbox poll, payment, and back.
+  timeout: 90_000,
+  expect: { timeout: 20_000 },
+  // Serial. The gateway rate-limits /auth/* to 10 requests a minute per apparent client
+  // (services/gateway/src/app.ts), and a browser cannot spoof x-forwarded-for the way
+  // infra/scripts/drive-checkouts.ts does — parallel walks would collect 429s and read as
+  // application failures.
+  workers: 1,
+  fullyParallel: false,
+  use: {
+    baseURL: process.env.WEB_URL ?? "http://localhost:5173",
+    trace: "on-first-retry",
+  },
+  projects: [
+    // Authenticates once and saves the state. Every walk starts signed in, so a full run costs
+    // two auth requests out of the ten a minute the gateway allows.
+    { name: "setup", testMatch: /auth\.setup\.ts/ },
+    {
+      name: "chromium",
+      dependencies: ["setup"],
+      use: { browserName: "chromium", storageState: "e2e/.auth/user.json" },
+      testIgnore: /auth\.setup\.ts/,
+    },
+  ],
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,6 +5,7 @@ import { Cart } from "./routes/Cart";
 import { Home } from "./routes/Home";
 import { Login } from "./routes/Login";
 import { Order } from "./routes/Order";
+import { Orders } from "./routes/Orders";
 import { Product } from "./routes/Product";
 import { Register } from "./routes/Register";
 
@@ -21,6 +22,14 @@ const router = createBrowserRouter([
         element: (
           <RequireAuth>
             <Cart />
+          </RequireAuth>
+        ),
+      },
+      {
+        path: "/orders",
+        element: (
+          <RequireAuth>
+            <Orders />
           </RequireAuth>
         ),
       },

--- a/apps/web/src/api/__tests__/cart.test.ts
+++ b/apps/web/src/api/__tests__/cart.test.ts
@@ -1,5 +1,5 @@
-import { setQuantity } from "../cart";
-import { HttpError } from "../errors";
+import { getCart, setQuantity } from "../cart";
+import { HttpError, SchemaMismatchError } from "../errors";
 
 function setCsrf(value: string | null) {
   document.cookie = value
@@ -38,4 +38,16 @@ it("still rejects on a non-404 error", async () => {
   const err = await setQuantity("p1", 3).catch((e) => e);
   expect(err).toBeInstanceOf(HttpError);
   expect((err as HttpError).status).toBe(500);
+});
+
+// Non-strict schemas let an additive server field pass silently, so drift only surfaced when
+// something downstream depended on the field nobody had noticed. Order asserts these same
+// schemas against its own responses, so strictness fails a backend test beside the change that
+// caused it.
+it("rejects a cart response carrying an unknown field", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn<typeof fetch>(async () => json({ userId: "u1", items: [], surprise: true }))
+  );
+  await expect(getCart()).rejects.toBeInstanceOf(SchemaMismatchError);
 });

--- a/apps/web/src/api/__tests__/orders.test.ts
+++ b/apps/web/src/api/__tests__/orders.test.ts
@@ -1,0 +1,33 @@
+import { describeCheckoutFailure } from "../orders";
+import { HttpError } from "../errors";
+
+// Spec §D1 of 8b asked the 422 recovery to name the product; it could not, because the body
+// carrying the id was discarded. This is that gap closed.
+it("names the unpriced product when the 422 body says which", () => {
+  const e = new HttpError(422, { error: "unpriced", productId: "p9" });
+  const message = describeCheckoutFailure(e, (id) =>
+    id === "p9" ? "Widget" : undefined
+  );
+  expect(message).toContain("Widget");
+  expect(message).toMatch(/remove it/i);
+});
+
+// The catalogue is a cache, and an order can reference a product it no longer holds.
+it("falls back to the generic wording when the id resolves to no name", () => {
+  const e = new HttpError(422, { productId: "gone" });
+  expect(describeCheckoutFailure(e, () => undefined)).toMatch(/one of these products/i);
+});
+
+it("falls back when the body names no product at all", () => {
+  expect(describeCheckoutFailure(new HttpError(422, {}))).toMatch(
+    /one of these products/i
+  );
+});
+
+it("still explains an empty cart", () => {
+  expect(describeCheckoutFailure(new HttpError(400))).toMatch(/empty/i);
+});
+
+it("stays generic for anything else", () => {
+  expect(describeCheckoutFailure(new Error("boom"))).toMatch(/could not place/i);
+});

--- a/apps/web/src/api/__tests__/request.test.ts
+++ b/apps/web/src/api/__tests__/request.test.ts
@@ -55,3 +55,32 @@ it("retries network failures but never schema mismatches or 4xx", () => {
   expect(retry(0, new HttpError(404))).toBe(false);
   expect(retry(5, new NetworkError("x"))).toBe(false); // bounded
 });
+
+// Order deliberately puts the offending productId in its 422 body, and until 8c the body was
+// discarded with the response — so checkout could only say "one of these products".
+it("attaches a JSON error body to HttpError", async () => {
+  mockFetch(
+    async () =>
+      new Response(JSON.stringify({ error: "unpriced", productId: "p9" }), {
+        status: 422,
+        headers: { "content-type": "application/json" },
+      })
+  );
+  const err = (await request("/orders", schema).catch((e) => e)) as HttpError;
+  expect(err.status).toBe(422);
+  expect(err.body).toEqual({ error: "unpriced", productId: "p9" });
+});
+
+// Best-effort: an HTML error page or a truncated payload must not turn one failure into two.
+it("leaves the body undefined when the error payload is not JSON", async () => {
+  mockFetch(
+    async () =>
+      new Response("<html>502</html>", {
+        status: 502,
+        headers: { "content-type": "text/html" },
+      })
+  );
+  const err = (await request("/orders", schema).catch((e) => e)) as HttpError;
+  expect(err.status).toBe(502);
+  expect(err.body).toBeUndefined();
+});

--- a/apps/web/src/api/__tests__/stream.test.ts
+++ b/apps/web/src/api/__tests__/stream.test.ts
@@ -1,0 +1,82 @@
+import { openOrderStream } from "../stream";
+
+type Listener = (e: { data?: string }) => void;
+
+// A fake that behaves like the real thing in the one way that matters: it delivers the
+// service's frames as a NAMED "status" event (services/order/src/app.ts writes
+// `event: status`). A fake built around onmessage would make every test here pass against a
+// page that receives nothing.
+function fakeEventSource() {
+  const listeners = new Map<string, Listener[]>();
+  let closed = false;
+  const es = {
+    addEventListener(type: string, fn: Listener) {
+      listeners.set(type, [...(listeners.get(type) ?? []), fn]);
+    },
+    close() {
+      closed = true;
+    },
+  };
+  return {
+    create: () => es,
+    emit: (type: string, data?: string) =>
+      (listeners.get(type) ?? []).forEach((fn) => fn({ data })),
+    isClosed: () => closed,
+  };
+}
+
+const noop = { onFrame: () => {}, onError: () => {} };
+
+it("delivers a named status frame", () => {
+  const fake = fakeEventSource();
+  const frames: unknown[] = [];
+  openOrderStream(
+    "o1",
+    { ...noop, onFrame: (f) => frames.push(f) },
+    { create: fake.create }
+  );
+  fake.emit("status", JSON.stringify({ orderId: "o1", status: "AWAITING_PAYMENT" }));
+  expect(frames).toEqual([{ orderId: "o1", status: "AWAITING_PAYMENT" }]);
+});
+
+it("subscribes same-origin under /api", () => {
+  const fake = fakeEventSource();
+  let seen = "";
+  openOrderStream("o 1", noop, {
+    create: (url) => {
+      seen = url;
+      return fake.create();
+    },
+  });
+  expect(seen).toBe("/api/orders/o%201/stream");
+});
+
+// The stream is a progress indicator; the query underneath it is the authority. A frame that
+// does not match the contract is dropped, not thrown.
+it("ignores a frame that is not a valid status", () => {
+  const fake = fakeEventSource();
+  const frames: unknown[] = [];
+  openOrderStream(
+    "o1",
+    { ...noop, onFrame: (f) => frames.push(f) },
+    { create: fake.create }
+  );
+  fake.emit("status", JSON.stringify({ orderId: "o1", status: "WAT" }));
+  fake.emit("status", "not json at all");
+  fake.emit("status", undefined);
+  expect(frames).toEqual([]);
+});
+
+it("reports errors and closes on demand", () => {
+  const fake = fakeEventSource();
+  let errors = 0;
+  const handle = openOrderStream(
+    "o1",
+    { ...noop, onError: () => (errors += 1) },
+    { create: fake.create }
+  );
+  fake.emit("error");
+  handle.close();
+  expect(errors).toBe(1);
+  expect(fake.isClosed()).toBe(true);
+});

--- a/apps/web/src/api/cart.ts
+++ b/apps/web/src/api/cart.ts
@@ -4,9 +4,10 @@ import { request } from "./request";
 import { API } from "./refresh";
 import { HttpError } from "./errors";
 
-// Every mutation answers 200 with a small JSON body — none of them is 204, so parsing is
-// safe. Schemas rather than z.unknown(): a mutation that silently starts answering something
-// else should fail here, not three screens later.
+// Every mutation answers a small JSON body — POST /cart/items answers 201, PATCH and DELETE
+// answer 200, and none of them is 204, so parsing is always safe. Schemas rather than
+// z.unknown(): a mutation that silently starts answering something else should fail here, not
+// three screens later.
 const AddedSchema = z.object({ productId: z.string() });
 const SetSchema = z.object({ productId: z.string(), quantity: z.number().int() });
 

--- a/apps/web/src/api/errors.ts
+++ b/apps/web/src/api/errors.ts
@@ -9,7 +9,13 @@ export class NetworkError extends Error {
 }
 
 export class HttpError extends Error {
-  constructor(readonly status: number) {
+  constructor(
+    readonly status: number,
+    // Parsed only when the response declared JSON, and only on a best-effort basis: a
+    // truncated or non-JSON error payload must not turn one failure into two. Everything still
+    // branches on `status` — `body` only ever adds detail to a message.
+    readonly body?: unknown
+  ) {
     super(`the gateway answered ${status}`);
     this.name = "HttpError";
   }

--- a/apps/web/src/api/orders.ts
+++ b/apps/web/src/api/orders.ts
@@ -1,4 +1,4 @@
-import { OrderDetailSchema, PlacedOrderSchema } from "@ecom/contracts";
+import { OrderDetailSchema, OrderListSchema, PlacedOrderSchema } from "@ecom/contracts";
 import { request } from "./request";
 import { API } from "./refresh";
 import { HttpError } from "./errors";
@@ -11,12 +11,35 @@ export const placeOrder = () =>
 export const getOrder = (id: string) =>
   request(`${API}/orders/${encodeURIComponent(id)}`, OrderDetailSchema);
 
+// Summaries, not details: the list carries a line COUNT, and the detail endpoint serves lines
+// to the page that needs them.
+export const listOrders = () => request(`${API}/orders`, OrderListSchema);
+
 // Two of the three failures are ordinary and recoverable in one click. Rendering them as
 // "something went wrong" would strand a user who could have fixed it.
-export function describeCheckoutFailure(e: unknown): string {
+//
+// `nameFor` joins the id Order returns against the catalogue the caller already has. It is
+// optional and defaults to "no name": the catalogue is a cache, and an order can reference a
+// product it no longer holds, so a missing name degrades the message rather than the flow.
+export function describeCheckoutFailure(
+  e: unknown,
+  nameFor: (id: string) => string | undefined = () => undefined
+): string {
   if (e instanceof HttpError && e.status === 400)
     return "Your cart is empty — it may have been placed in another tab.";
-  if (e instanceof HttpError && e.status === 422)
-    return "One of these products has no price yet. Remove it and try again.";
+  if (e instanceof HttpError && e.status === 422) {
+    const id = productIdOf(e.body);
+    const name = id === undefined ? undefined : nameFor(id);
+    return name
+      ? `${name} has no price yet. Remove it and try again.`
+      : "One of these products has no price yet. Remove it and try again.";
+  }
   return "Could not place the order. Try again.";
+}
+
+function productIdOf(body: unknown): string | undefined {
+  if (typeof body !== "object" || body === null || !("productId" in body))
+    return undefined;
+  const id = (body as { productId: unknown }).productId;
+  return typeof id === "string" ? id : undefined;
 }

--- a/apps/web/src/api/request.ts
+++ b/apps/web/src/api/request.ts
@@ -35,6 +35,18 @@ async function send(path: string, init: RequestInit_): Promise<Response> {
   });
 }
 
+// Read only what the server said is JSON, and never let reading it throw: the caller is
+// already handling a failure, and a second one raised from the error path would replace a
+// precise status with a parse error.
+async function readErrorBody(res: Response): Promise<unknown> {
+  if (!res.headers.get("content-type")?.includes("application/json")) return undefined;
+  try {
+    return await res.json();
+  } catch {
+    return undefined;
+  }
+}
+
 export async function request<T>(
   path: string,
   schema: ZodType<T>,
@@ -64,7 +76,7 @@ export async function request<T>(
     if (res.status === 401) throw new UnauthenticatedError();
   }
 
-  if (!res.ok) throw new HttpError(res.status);
+  if (!res.ok) throw new HttpError(res.status, await readErrorBody(res));
 
   let body: unknown;
   try {

--- a/apps/web/src/api/stream.ts
+++ b/apps/web/src/api/stream.ts
@@ -1,0 +1,46 @@
+import { OrderStatusSchema, type OrderStatus } from "@ecom/contracts";
+import { z } from "zod";
+
+export type StatusFrame = { orderId: string; status: OrderStatus };
+
+const FrameSchema = z.object({ orderId: z.string(), status: OrderStatusSchema });
+
+// Structural, not the DOM's EventSource: the constructor is undefined in the test environment
+// (jsdom does not implement it, and Node 22 has no global either), so the factory has to be
+// injectable or none of the ladder above this module could be tested at all.
+export type EventSourceLike = {
+  addEventListener(type: string, fn: (e: { data?: string }) => void): void;
+  close(): void;
+};
+export type EventSourceFactory = (url: string) => EventSourceLike;
+
+const defaultCreate: EventSourceFactory = (url) =>
+  new EventSource(url) as unknown as EventSourceLike;
+
+export function openOrderStream(
+  orderId: string,
+  handlers: { onFrame: (f: StatusFrame) => void; onError: () => void },
+  opts: { create?: EventSourceFactory } = {}
+): { close: () => void } {
+  const create = opts.create ?? defaultCreate;
+  // Same-origin under /api, so the session cookie rides automatically — EventSource cannot set
+  // headers, which is why the gateway authenticates this stream from the cookie.
+  const es = create(`/api/orders/${encodeURIComponent(orderId)}/stream`);
+
+  // NAMED event. The service writes `event: status`, and EventSource routes a named event ONLY
+  // to a matching addEventListener — `onmessage` would never fire.
+  es.addEventListener("status", (e) => {
+    let raw: unknown;
+    try {
+      raw = JSON.parse(e.data ?? "");
+    } catch {
+      return;
+    }
+    const parsed = FrameSchema.safeParse(raw);
+    if (parsed.success) handlers.onFrame(parsed.data);
+  });
+
+  es.addEventListener("error", () => handlers.onError());
+
+  return { close: () => es.close() };
+}

--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -26,6 +26,14 @@ export function Layout() {
 
   return (
     <div className="mx-auto max-w-6xl p-6">
+      {/* Visible only when focused: one header is shared by every route, so without this a
+          keyboard user tabs the whole nav again on every navigation. */}
+      <a
+        href="#main"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:border focus:border-[color:var(--color-line-strong)] focus:bg-[color:var(--color-surface)] focus:px-3 focus:py-2"
+      >
+        Skip to content
+      </a>
       <header className="mb-8 flex items-center justify-between">
         <Link to="/" className="text-lg font-medium">
           Storefront
@@ -48,7 +56,9 @@ export function Layout() {
           )}
         </nav>
       </header>
-      <Outlet />
+      <main id="main">
+        <Outlet />
+      </main>
     </div>
   );
 }

--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -35,7 +35,12 @@ export function Layout() {
             Cart ({count})
           </Link>
           {data?.authenticated ? (
-            <Button onClick={signOut}>Sign out</Button>
+            <>
+              <Link to="/orders" className="datum text-sm">
+                Orders
+              </Link>
+              <Button onClick={signOut}>Sign out</Button>
+            </>
           ) : (
             <Link to="/login" className="datum text-sm underline">
               Sign in

--- a/apps/web/src/components/OrderTracker.tsx
+++ b/apps/web/src/components/OrderTracker.tsx
@@ -1,0 +1,69 @@
+import type { OrderStatus } from "@ecom/contracts";
+import { stepsFor, type FailedAt, type Step, type StepState } from "../order/saga-steps";
+
+// Colour encodes saga state per the design language — so every step ALSO carries a glyph and a
+// spelled-out condition, and the pipeline stays readable in greyscale and to a screen reader.
+const GLYPH: Record<StepState, string> = {
+  done: "✓",
+  active: "●",
+  failed: "✕",
+  pending: "○",
+};
+const CONDITION: Record<StepState, string> = {
+  done: "done",
+  active: "in progress",
+  failed: "failed",
+  pending: "waiting",
+};
+const TONE: Record<StepState, string> = {
+  done: "text-[color:var(--color-ok)]",
+  active: "text-[color:var(--color-live)]",
+  failed: "text-[color:var(--color-fail)]",
+  pending: "text-[color:var(--color-muted)]",
+};
+
+function announce(status: OrderStatus, steps: Step[]): string {
+  if (status === "CONFIRMED") return "Order confirmed";
+  if (status === "CANCELLED") {
+    const failed = steps.find((s) => s.state === "failed");
+    return failed ? `Order cancelled — ${failed.label} failed` : "Order cancelled";
+  }
+  const active = steps.find((s) => s.state === "active");
+  return active ? `${active.label} in progress` : "Order placed";
+}
+
+export function OrderTracker({
+  status,
+  failedAt,
+}: {
+  status: OrderStatus;
+  failedAt: FailedAt;
+}) {
+  const steps = stepsFor(status, failedAt);
+  return (
+    <div className="rounded-lg border border-[color:var(--color-line)] bg-[color:var(--color-surface)] p-4">
+      <ol className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-6">
+        {steps.map((s) => (
+          <li
+            key={s.key}
+            aria-current={s.state === "active" ? "step" : undefined}
+            className="flex items-center gap-2 sm:flex-1"
+          >
+            <span
+              aria-hidden="true"
+              className={`${TONE[s.state]} ${s.state === "active" ? "tracker-pulse" : ""}`}
+            >
+              {GLYPH[s.state]}
+            </span>
+            <span className="datum text-sm">{s.label}</span>
+            <span className="sr-only">{CONDITION[s.state]}</span>
+          </li>
+        ))}
+      </ol>
+      {/* One announcement per transition, polite: three states can land in a few seconds. */}
+      <p role="status" aria-live="polite" className="sr-only">
+        {announce(status, steps)}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/__tests__/Layout.test.tsx
+++ b/apps/web/src/components/__tests__/Layout.test.tsx
@@ -1,0 +1,53 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { makeQueryClient } from "../../api/queryClient";
+import * as sessionApi from "../../api/session";
+import { Layout } from "../Layout";
+
+function renderLayout() {
+  const router = createMemoryRouter(
+    [{ element: <Layout />, children: [{ index: true, element: <h1>Home</h1> }] }],
+    { initialEntries: ["/"] }
+  );
+  return render(
+    <QueryClientProvider client={makeQueryClient()}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  );
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+// Every page shares one header, so without a skip link a keyboard user tabs the whole nav on
+// every navigation before reaching what they came for.
+it("offers a skip link that targets the main landmark", async () => {
+  vi.spyOn(sessionApi, "probeSession").mockResolvedValue({
+    authenticated: false,
+    cart: null,
+  });
+  renderLayout();
+  const skip = screen.getByRole("link", { name: /skip to content/i });
+  expect(skip).toHaveAttribute("href", "#main");
+  expect(screen.getByRole("main")).toHaveAttribute("id", "main");
+});
+
+it("shows the orders link only to a signed-in visitor", async () => {
+  vi.spyOn(sessionApi, "probeSession").mockResolvedValue({
+    authenticated: false,
+    cart: null,
+  });
+  const { unmount } = renderLayout();
+  expect(screen.queryByRole("link", { name: /^orders$/i })).not.toBeInTheDocument();
+  unmount();
+
+  vi.spyOn(sessionApi, "probeSession").mockResolvedValue({
+    authenticated: true,
+    cart: { userId: "u1", items: [] },
+  });
+  renderLayout();
+  expect(await screen.findByRole("link", { name: /^orders$/i })).toHaveAttribute(
+    "href",
+    "/orders"
+  );
+});

--- a/apps/web/src/components/__tests__/OrderTracker.test.tsx
+++ b/apps/web/src/components/__tests__/OrderTracker.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { OrderTracker } from "../OrderTracker";
+
+it("marks the step in flight and announces it politely", () => {
+  render(<OrderTracker status="AWAITING_PAYMENT" failedAt={null} />);
+  const current = screen.getByRole("listitem", { current: "step" });
+  expect(current).toHaveTextContent("Payment");
+  const live = screen.getByRole("status");
+  expect(live).toHaveTextContent(/payment/i);
+  // Polite, not assertive: the saga can produce three transitions in a few seconds and none of
+  // them is an interruption.
+  expect(live).toHaveAttribute("aria-live", "polite");
+});
+
+// The design language encodes saga state in colour, so the state must ALSO be readable as
+// text — in greyscale, and to a screen reader.
+it("states every step's condition in text, not only in colour", () => {
+  render(<OrderTracker status="PENDING" failedAt={null} />);
+  for (const label of ["Order placed", "Inventory reserved", "Payment", "Confirmed"])
+    expect(screen.getByText(label)).toBeInTheDocument();
+  expect(screen.getByText("Inventory reserved").closest("li")).toHaveTextContent(
+    /in progress/i
+  );
+  expect(screen.getByText("Order placed").closest("li")).toHaveTextContent(/done/i);
+});
+
+it("shows the compensation path when the failure was observed", () => {
+  render(<OrderTracker status="CANCELLED" failedAt="AWAITING_PAYMENT" />);
+  expect(screen.getByText("Payment").closest("li")).toHaveTextContent(/failed/i);
+  expect(screen.getByRole("status")).toHaveTextContent(/cancelled/i);
+});
+
+it("blames no step on a cold-loaded cancellation", () => {
+  render(<OrderTracker status="CANCELLED" failedAt={null} />);
+  expect(screen.queryByText(/failed/i)).not.toBeInTheDocument();
+  expect(screen.getByRole("status")).toHaveTextContent(/cancelled/i);
+});
+
+it("completes every step once confirmed", () => {
+  render(<OrderTracker status="CONFIRMED" failedAt={null} />);
+  expect(screen.queryByRole("listitem", { current: "step" })).not.toBeInTheDocument();
+  expect(screen.getByRole("status")).toHaveTextContent(/confirmed/i);
+});
+
+// The pulse is a class, so `prefers-reduced-motion` can remove it in CSS rather than the
+// component branching on a media query it cannot see in jsdom.
+it("marks the active step with the animated class, and nothing else", () => {
+  const { container } = render(<OrderTracker status="PENDING" failedAt={null} />);
+  expect(container.querySelectorAll(".tracker-pulse")).toHaveLength(1);
+});

--- a/apps/web/src/hooks/__tests__/useOrderStream.test.tsx
+++ b/apps/web/src/hooks/__tests__/useOrderStream.test.tsx
@@ -1,0 +1,155 @@
+import type { ReactNode } from "react";
+import { QueryClientProvider, type QueryClient } from "@tanstack/react-query";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { makeQueryClient } from "../../api/queryClient";
+import * as refreshApi from "../../api/refresh";
+import { useOrderStream } from "../useOrderStream";
+
+type Listener = (e: { data?: string }) => void;
+
+// Records every EventSource the hook opens, so the ladder's "close and reopen" rung is
+// observable rather than inferred.
+function harness() {
+  const instances: Array<{ listeners: Map<string, Listener[]>; closed: boolean }> = [];
+  const create = () => {
+    const inst = { listeners: new Map<string, Listener[]>(), closed: false };
+    instances.push(inst);
+    return {
+      addEventListener(type: string, fn: Listener) {
+        inst.listeners.set(type, [...(inst.listeners.get(type) ?? []), fn]);
+      },
+      close() {
+        inst.closed = true;
+      },
+    };
+  };
+  const emit = (i: number, type: string, data?: string) =>
+    (instances[i].listeners.get(type) ?? []).forEach((fn) => fn({ data }));
+  return { create, emit, instances };
+}
+
+const wrapperFor = (client: QueryClient) =>
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+
+const cachedOrder = (status: string) => ({
+  id: "o1",
+  userId: "u1",
+  status,
+  totalPrice: 100,
+  items: [{ productId: "p1", quantity: 1, unitPrice: 100 }],
+  createdAt: "2026-08-04T00:00:00.000Z",
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+it("advances an order already in the cache", async () => {
+  const client = makeQueryClient();
+  const h = harness();
+  client.setQueryData(["order", "o1"], cachedOrder("PENDING"));
+  renderHook(() => useOrderStream("o1", { create: h.create }), {
+    wrapper: wrapperFor(client),
+  });
+  act(() =>
+    h.emit(0, "status", JSON.stringify({ orderId: "o1", status: "AWAITING_PAYMENT" }))
+  );
+  await waitFor(() =>
+    expect((client.getQueryData(["order", "o1"]) as { status: string }).status).toBe(
+      "AWAITING_PAYMENT"
+    )
+  );
+  // The lines survive: the stream advances an order, it never rebuilds one.
+  expect(
+    (client.getQueryData(["order", "o1"]) as { items: unknown[] }).items
+  ).toHaveLength(1);
+});
+
+// The service sends the current status on subscribe, so a frame routinely beats the GET. A
+// {status}-only object would render an order with no lines — 8b's fabricated $0.00, again.
+it("drops a frame that arrives before the order is cached", () => {
+  const client = makeQueryClient();
+  const h = harness();
+  renderHook(() => useOrderStream("o1", { create: h.create }), {
+    wrapper: wrapperFor(client),
+  });
+  act(() => h.emit(0, "status", JSON.stringify({ orderId: "o1", status: "CONFIRMED" })));
+  expect(client.getQueryData(["order", "o1"])).toBeUndefined();
+});
+
+it("closes, refreshes once, and reopens on the first error", async () => {
+  const h = harness();
+  const refresh = vi.spyOn(refreshApi, "refreshSession").mockResolvedValue(true);
+  renderHook(() => useOrderStream("o1", { create: h.create }), {
+    wrapper: wrapperFor(makeQueryClient()),
+  });
+  act(() => h.emit(0, "error"));
+  await waitFor(() => expect(h.instances).toHaveLength(2));
+  expect(h.instances[0].closed).toBe(true);
+  expect(refresh).toHaveBeenCalledTimes(1);
+});
+
+it("falls back to polling on the third error and not before", async () => {
+  const h = harness();
+  vi.spyOn(refreshApi, "refreshSession").mockResolvedValue(true);
+  const { result } = renderHook(() => useOrderStream("o1", { create: h.create }), {
+    wrapper: wrapperFor(makeQueryClient()),
+  });
+  act(() => h.emit(0, "error"));
+  await waitFor(() => expect(h.instances).toHaveLength(2));
+  act(() => h.emit(1, "error"));
+  expect(result.current.polling).toBe(false);
+  act(() => h.emit(1, "error"));
+  await waitFor(() => expect(result.current.polling).toBe(true));
+  expect(h.instances[1].closed).toBe(true);
+  // One transport at a time: nothing reopens after the ladder gives up.
+  expect(h.instances).toHaveLength(2);
+});
+
+it("remembers the status it was in when a cancellation arrived", async () => {
+  const client = makeQueryClient();
+  const h = harness();
+  client.setQueryData(["order", "o1"], cachedOrder("PENDING"));
+  const { result } = renderHook(() => useOrderStream("o1", { create: h.create }), {
+    wrapper: wrapperFor(client),
+  });
+  act(() =>
+    h.emit(0, "status", JSON.stringify({ orderId: "o1", status: "AWAITING_PAYMENT" }))
+  );
+  act(() => h.emit(0, "status", JSON.stringify({ orderId: "o1", status: "CANCELLED" })));
+  await waitFor(() => expect(result.current.failedAt).toBe("AWAITING_PAYMENT"));
+});
+
+it("blames nothing when the first frame it ever sees is CANCELLED", async () => {
+  const client = makeQueryClient();
+  const h = harness();
+  client.setQueryData(["order", "o1"], cachedOrder("CANCELLED"));
+  const { result } = renderHook(() => useOrderStream("o1", { create: h.create }), {
+    wrapper: wrapperFor(client),
+  });
+  act(() => h.emit(0, "status", JSON.stringify({ orderId: "o1", status: "CANCELLED" })));
+  await waitFor(() => expect(h.instances[0].closed).toBe(true));
+  expect(result.current.failedAt).toBeNull();
+});
+
+it("stops everything on a terminal frame", async () => {
+  const h = harness();
+  const { result } = renderHook(() => useOrderStream("o1", { create: h.create }), {
+    wrapper: wrapperFor(makeQueryClient()),
+  });
+  act(() => h.emit(0, "status", JSON.stringify({ orderId: "o1", status: "CONFIRMED" })));
+  await waitFor(() => expect(h.instances[0].closed).toBe(true));
+  expect(result.current.polling).toBe(false);
+  // A settled order must not resurrect the stream on a late error.
+  act(() => h.emit(0, "error"));
+  expect(h.instances).toHaveLength(1);
+});
+
+it("closes the stream on unmount", () => {
+  const h = harness();
+  const { unmount } = renderHook(() => useOrderStream("o1", { create: h.create }), {
+    wrapper: wrapperFor(makeQueryClient()),
+  });
+  unmount();
+  expect(h.instances[0].closed).toBe(true);
+});

--- a/apps/web/src/hooks/useOrderStream.ts
+++ b/apps/web/src/hooks/useOrderStream.ts
@@ -1,0 +1,112 @@
+import { useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import type { OrderDetail, OrderStatus } from "@ecom/contracts";
+import { openOrderStream, type EventSourceFactory } from "../api/stream";
+import { refreshSession } from "../api/refresh";
+import type { FailedAt } from "../order/saga-steps";
+
+// Chosen against the saga_duration p(99)<5000 threshold in k6/checkout.js:21 — fast enough
+// that a fallback user sees the pipeline move, slow enough that a settled page is not a load
+// source.
+export const POLL_INTERVAL_MS = 3000;
+export const MAX_STREAM_ERRORS = 3;
+
+const isTerminal = (s: OrderStatus) => s === "CONFIRMED" || s === "CANCELLED";
+
+/**
+ * Liveness for one order, as a ladder that TERMINATES.
+ *
+ * EventSource reconnects forever on its own and exposes no status code, so an expired access
+ * token, a 404 for someone else's order, and a dropped connection are the same event. Counting
+ * errors rather than interpreting them is what lets this stop: rung 1 fixes the one cause the
+ * client can fix, rung 3 gives up on the transport, and a terminal status ends everything.
+ *
+ * Never SSE and polling at once — parallel polling would keep the page correct while the
+ * stream was completely broken, which is the failure this whole phase exists to make visible.
+ */
+export function useOrderStream(
+  orderId: string,
+  opts: { create?: EventSourceFactory } = {}
+): { polling: boolean; failedAt: FailedAt } {
+  const qc = useQueryClient();
+  const [polling, setPolling] = useState(false);
+  const [failedAt, setFailedAt] = useState<FailedAt>(null);
+  const create = opts.create;
+
+  // Refs, not state: the ladder must not re-render the page, and a stale closure over the
+  // error count would let every error in a burst read zero.
+  const lastStatus = useRef<OrderStatus | null>(null);
+  const errors = useRef(0);
+  const refreshing = useRef(false);
+  const handle = useRef<{ close: () => void } | null>(null);
+  const stopped = useRef(false);
+
+  useEffect(() => {
+    stopped.current = false;
+    errors.current = 0;
+    lastStatus.current = null;
+
+    const stop = () => {
+      stopped.current = true;
+      handle.current?.close();
+      handle.current = null;
+    };
+
+    const open = () => {
+      if (stopped.current) return;
+      handle.current = openOrderStream(
+        orderId,
+        {
+          onFrame: (f) => {
+            // Advance an existing order; never materialise one. The service sends the current
+            // status on subscribe, so a frame routinely beats GET /orders/:id, and a
+            // {status}-only object would render an order with no lines.
+            qc.setQueryData<OrderDetail>(["order", orderId], (old) =>
+              old ? { ...old, status: f.status } : old
+            );
+            // Only a transition observed live says which leg failed. A cold load whose first
+            // frame is already CANCELLED leaves this null, and the tracker blames no step.
+            if (
+              f.status === "CANCELLED" &&
+              lastStatus.current &&
+              !isTerminal(lastStatus.current)
+            )
+              setFailedAt(lastStatus.current);
+            lastStatus.current = f.status;
+            if (isTerminal(f.status)) {
+              setPolling(false);
+              stop();
+            }
+          },
+          onError: () => {
+            if (stopped.current || refreshing.current) return;
+            errors.current += 1;
+            if (errors.current === 1) {
+              // Close BEFORE refreshing. EventSource reconnects on its own ~3s timer, and that
+              // attempt would 401 again mid-refresh and spend a second rung on a problem
+              // already being fixed.
+              refreshing.current = true;
+              handle.current?.close();
+              handle.current = null;
+              void refreshSession().finally(() => {
+                refreshing.current = false;
+                open();
+              });
+              return;
+            }
+            if (errors.current >= MAX_STREAM_ERRORS) {
+              stop();
+              setPolling(true);
+            }
+          },
+        },
+        create ? { create } : {}
+      );
+    };
+
+    open();
+    return stop;
+  }, [orderId, qc, create]);
+
+  return { polling, failedAt };
+}

--- a/apps/web/src/order/__tests__/saga-steps.test.ts
+++ b/apps/web/src/order/__tests__/saga-steps.test.ts
@@ -1,0 +1,69 @@
+import { stepsFor, type FailedAt } from "../saga-steps";
+
+const stateOf = (status: Parameters<typeof stepsFor>[0], failedAt: FailedAt = null) =>
+  Object.fromEntries(stepsFor(status, failedAt).map((s) => [s.key, s.state]));
+
+it("PENDING means placed, with the reservation in flight", () => {
+  expect(stateOf("PENDING")).toEqual({
+    placed: "done",
+    reserved: "active",
+    payment: "pending",
+    confirmed: "pending",
+  });
+});
+
+// The whole basis of the tracker: an order cannot reach AWAITING_PAYMENT unless the
+// reservation succeeded (services/order/src/transition.ts:14).
+it("AWAITING_PAYMENT proves the reservation succeeded", () => {
+  expect(stateOf("AWAITING_PAYMENT")).toEqual({
+    placed: "done",
+    reserved: "done",
+    payment: "active",
+    confirmed: "pending",
+  });
+});
+
+it("CONFIRMED completes every step", () => {
+  expect(stateOf("CONFIRMED")).toEqual({
+    placed: "done",
+    reserved: "done",
+    payment: "done",
+    confirmed: "done",
+  });
+});
+
+it("a cancellation seen during PENDING failed at the reservation", () => {
+  expect(stateOf("CANCELLED", "PENDING")).toEqual({
+    placed: "done",
+    reserved: "failed",
+    payment: "pending",
+    confirmed: "pending",
+  });
+});
+
+it("a cancellation seen during AWAITING_PAYMENT failed at the payment", () => {
+  expect(stateOf("CANCELLED", "AWAITING_PAYMENT")).toEqual({
+    placed: "done",
+    reserved: "done",
+    payment: "failed",
+    confirmed: "pending",
+  });
+});
+
+// Cold load: the status alone cannot say which leg failed, and guessing "payment" would state
+// a falsehood for every reservation-failed order.
+it("a cold-loaded cancellation blames no step", () => {
+  const states = stateOf("CANCELLED");
+  expect(Object.values(states)).not.toContain("failed");
+  expect(states.placed).toBe("done");
+});
+
+it("labels every step, in saga order", () => {
+  expect(stepsFor("PENDING").map((s) => s.key)).toEqual([
+    "placed",
+    "reserved",
+    "payment",
+    "confirmed",
+  ]);
+  expect(stepsFor("PENDING").every((s) => s.label.length > 0)).toBe(true);
+});

--- a/apps/web/src/order/saga-steps.ts
+++ b/apps/web/src/order/saga-steps.ts
@@ -1,0 +1,70 @@
+import type { OrderStatus } from "@ecom/contracts";
+
+export type StepKey = "placed" | "reserved" | "payment" | "confirmed";
+export type StepState = "done" | "active" | "failed" | "pending";
+export type Step = { key: StepKey; label: string; state: StepState };
+
+// The status the tracker last saw before a terminal CANCELLED arrived. Null when the page was
+// loaded cold on an already-cancelled order — the one case where the failing leg is unknowable.
+export type FailedAt = "PENDING" | "AWAITING_PAYMENT" | null;
+
+const LABELS: Record<StepKey, string> = {
+  placed: "Order placed",
+  reserved: "Inventory reserved",
+  payment: "Payment",
+  confirmed: "Confirmed",
+};
+
+const ORDER: StepKey[] = ["placed", "reserved", "payment", "confirmed"];
+
+// The choreographed saga has more transitions than Order has statuses, and THIS IS THE ONLY
+// MODULE ALLOWED TO KNOW how the two relate. An order cannot reach AWAITING_PAYMENT unless the
+// reservation succeeded (services/order/src/transition.ts:14), so the status is already the
+// evidence a "reserved" step needs — no saga sub-events, no migration.
+function statesFor(status: OrderStatus, failedAt: FailedAt): Record<StepKey, StepState> {
+  switch (status) {
+    case "PENDING":
+      return {
+        placed: "done",
+        reserved: "active",
+        payment: "pending",
+        confirmed: "pending",
+      };
+    case "AWAITING_PAYMENT":
+      return {
+        placed: "done",
+        reserved: "done",
+        payment: "active",
+        confirmed: "pending",
+      };
+    case "CONFIRMED":
+      return { placed: "done", reserved: "done", payment: "done", confirmed: "done" };
+    case "CANCELLED":
+      // Two different failures produce one status. Only a transition observed live says which.
+      if (failedAt === "PENDING")
+        return {
+          placed: "done",
+          reserved: "failed",
+          payment: "pending",
+          confirmed: "pending",
+        };
+      if (failedAt === "AWAITING_PAYMENT")
+        return {
+          placed: "done",
+          reserved: "done",
+          payment: "failed",
+          confirmed: "pending",
+        };
+      return {
+        placed: "done",
+        reserved: "pending",
+        payment: "pending",
+        confirmed: "pending",
+      };
+  }
+}
+
+export function stepsFor(status: OrderStatus, failedAt: FailedAt = null): Step[] {
+  const states = statesFor(status, failedAt);
+  return ORDER.map((key) => ({ key, label: LABELS[key], state: states[key] }));
+}

--- a/apps/web/src/routes/Cart.tsx
+++ b/apps/web/src/routes/Cart.tsx
@@ -76,7 +76,7 @@ export function Cart() {
         // refetch lands on the real EmptyState instead of stale lines and a live "Place order"
         // button rendering above an alert that contradicts them.
         await invalidate();
-        setCheckoutError(describeCheckoutFailure(e));
+        setCheckoutError(describeCheckoutFailure(e, (id) => byId.get(id)?.name));
         return;
       }
       setCheckoutError(describeCheckoutFailure(e));

--- a/apps/web/src/routes/Order.tsx
+++ b/apps/web/src/routes/Order.tsx
@@ -1,16 +1,29 @@
 import { useQuery } from "@tanstack/react-query";
+import type { OrderStatus } from "@ecom/contracts";
 import { Link, useParams } from "react-router";
 import { HttpError } from "../api/errors";
 import { getOrder } from "../api/orders";
 import { listProducts } from "../api/products";
 import { Badge } from "../components/Badge";
 import { ErrorState } from "../components/ErrorState";
+import { OrderTracker } from "../components/OrderTracker";
 import { Price } from "../components/Price";
 import { Skeleton } from "../components/Skeleton";
+import { POLL_INTERVAL_MS, useOrderStream } from "../hooks/useOrderStream";
+
+const isTerminal = (s?: OrderStatus) => s === "CONFIRMED" || s === "CANCELLED";
 
 export function Order() {
   const { id = "" } = useParams();
-  const order = useQuery({ queryKey: ["order", id], queryFn: () => getOrder(id) });
+  const { polling, failedAt } = useOrderStream(id);
+  const order = useQuery({
+    queryKey: ["order", id],
+    queryFn: () => getOrder(id),
+    // The fallback transport has to stop itself: in polling mode no frame will ever arrive to
+    // announce the terminal state, so the query is what notices the order settled.
+    refetchInterval: (q) =>
+      polling && !isTerminal(q.state.data?.status) ? POLL_INTERVAL_MS : false,
+  });
   const products = useQuery({ queryKey: ["products"], queryFn: listProducts });
 
   if (order.isPending) return <Skeleton />;
@@ -33,9 +46,11 @@ export function Order() {
   return (
     <div className="flex flex-col gap-6">
       <div className="flex items-center gap-3">
-        <h1 className="text-2xl">Order placed</h1>
+        {/* Not "Order placed": this page is also where history lands. */}
+        <h1 className="text-2xl">Order</h1>
         <Badge>{order.data.status}</Badge>
       </div>
+      <OrderTracker status={order.data.status} failedAt={failedAt} />
       <ul className="flex flex-col gap-2">
         {order.data.items.map((i) => (
           <li

--- a/apps/web/src/routes/Orders.tsx
+++ b/apps/web/src/routes/Orders.tsx
@@ -1,0 +1,43 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router";
+import { listOrders } from "../api/orders";
+import { Badge } from "../components/Badge";
+import { EmptyState } from "../components/EmptyState";
+import { ErrorState } from "../components/ErrorState";
+import { Price } from "../components/Price";
+import { Skeleton } from "../components/Skeleton";
+
+// This page and the API it reads share a name and cannot collide: the browser calls /api/orders
+// and the router owns /orders, which is the whole point of 8a's prefix decision.
+export function Orders() {
+  const orders = useQuery({ queryKey: ["orders"], queryFn: listOrders });
+
+  if (orders.isPending) return <Skeleton />;
+  if (orders.error)
+    return <ErrorState error={orders.error} onRetry={() => orders.refetch()} />;
+  if (orders.data.length === 0)
+    return <EmptyState message="No orders yet — placing one starts the pipeline." />;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h1 className="text-2xl">Your orders</h1>
+      <ul className="flex flex-col">
+        {orders.data.map((o) => (
+          <li key={o.id} className="border-b border-[color:var(--color-line)]">
+            <Link
+              to={`/orders/${o.id}`}
+              className="flex flex-wrap items-center justify-between gap-3 py-3"
+            >
+              <span className="datum text-sm">{o.id}</span>
+              <span className="datum text-xs text-[color:var(--color-muted)]">
+                {o.itemCount} items
+              </span>
+              <Badge>{o.status}</Badge>
+              <Price minorUnits={o.totalPrice} />
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/routes/__tests__/Cart.test.tsx
+++ b/apps/web/src/routes/__tests__/Cart.test.tsx
@@ -199,3 +199,42 @@ it("shows the real empty state, not stale lines plus a contradicting alert, afte
   expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   expect(screen.queryByRole("button", { name: /place order/i })).not.toBeInTheDocument();
 });
+
+// Deferred out of 8b: the stepper's floor. Decrementing the last unit removes the line via
+// DELETE rather than PATCHing a zero — the stepper must not clamp at 1 and strand it.
+it("removes the line when the last unit is decremented", async () => {
+  vi.spyOn(session, "probeSession").mockResolvedValue({
+    authenticated: true,
+    cart: { userId: "u1", items: [{ productId: "p1", quantity: 1 }] },
+  });
+  vi.spyOn(productsApi, "listProducts").mockResolvedValue([product()]);
+  const remove = vi.spyOn(cartApi, "removeItem").mockResolvedValue({ productId: "p1" });
+  const set = vi.spyOn(cartApi, "setQuantity");
+  renderCart();
+  await screen.findByText("Widget");
+  fireEvent.click(screen.getByRole("button", { name: /decrease/i }));
+  expect(remove).toHaveBeenCalledWith("p1");
+  expect(set).not.toHaveBeenCalled();
+});
+
+// Also deferred out of 8b: the estimate is a sum across lines, not the first line's price.
+it("estimates a multi-line cart as the sum of its lines", async () => {
+  vi.spyOn(session, "probeSession").mockResolvedValue({
+    authenticated: true,
+    cart: {
+      userId: "u1",
+      items: [
+        { productId: "p1", quantity: 2 },
+        { productId: "p2", quantity: 1 },
+      ],
+    },
+  });
+  vi.spyOn(productsApi, "listProducts").mockResolvedValue([
+    product(),
+    product({ id: "p2", name: "Gadget", price: 250 }),
+  ]);
+  renderCart();
+  await screen.findByText("Gadget");
+  // 900 × 2 + 250 = 2050
+  expect(screen.getByText("$20.50")).toBeInTheDocument();
+});

--- a/apps/web/src/routes/__tests__/Order.test.tsx
+++ b/apps/web/src/routes/__tests__/Order.test.tsx
@@ -7,6 +7,14 @@ import * as ordersApi from "../../api/orders";
 import * as productsApi from "../../api/products";
 import { Order } from "../Order";
 
+// The route opens a real EventSource, which does not exist in jsdom (nor as a Node 22 global).
+// The ladder itself is proved in useOrderStream's own suite; here it is stubbed so these tests
+// stay about the page.
+vi.mock("../../hooks/useOrderStream", () => ({
+  useOrderStream: () => ({ polling: false, failedAt: null }),
+  POLL_INTERVAL_MS: 3000,
+}));
+
 function renderAt(id: string) {
   const router = createMemoryRouter([{ path: "/orders/:id", element: <Order /> }], {
     initialEntries: [`/orders/${id}`],
@@ -53,4 +61,14 @@ it("renders a not-found view for someone else's order", async () => {
   vi.spyOn(productsApi, "listProducts").mockResolvedValue([]);
   renderAt("nope");
   expect(await screen.findByText(/not found/i)).toBeInTheDocument();
+});
+
+it("renders the pipeline for the order's status", async () => {
+  vi.spyOn(ordersApi, "getOrder").mockResolvedValue(
+    detail({ status: "AWAITING_PAYMENT" })
+  );
+  vi.spyOn(productsApi, "listProducts").mockResolvedValue([]);
+  renderAt("o1");
+  expect(await screen.findByText("Inventory reserved")).toBeInTheDocument();
+  expect(screen.getByRole("listitem", { current: "step" })).toHaveTextContent("Payment");
 });

--- a/apps/web/src/routes/__tests__/Orders.test.tsx
+++ b/apps/web/src/routes/__tests__/Orders.test.tsx
@@ -1,0 +1,65 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { makeQueryClient } from "../../api/queryClient";
+import { HttpError } from "../../api/errors";
+import * as ordersApi from "../../api/orders";
+import { Orders } from "../Orders";
+
+function renderList() {
+  const router = createMemoryRouter(
+    [
+      { path: "/orders", element: <Orders /> },
+      { path: "/orders/:id", element: <div>detail</div> },
+    ],
+    { initialEntries: ["/orders"] }
+  );
+  return render(
+    <QueryClientProvider client={makeQueryClient()}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  );
+}
+
+const summary = (over = {}) => ({
+  id: "o2",
+  status: "CONFIRMED" as const,
+  totalPrice: 2500,
+  itemCount: 2,
+  createdAt: "2026-08-04T10:00:00.000Z",
+  ...over,
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+it("lists the caller's orders with their status and total", async () => {
+  vi.spyOn(ordersApi, "listOrders").mockResolvedValue([summary()]);
+  renderList();
+  expect(await screen.findByText("o2")).toBeInTheDocument();
+  expect(screen.getByText("CONFIRMED")).toBeInTheDocument();
+  expect(screen.getByText("$25.00")).toBeInTheDocument();
+  expect(screen.getByText(/2 items/)).toBeInTheDocument();
+});
+
+it("links each row to its order", async () => {
+  vi.spyOn(ordersApi, "listOrders").mockResolvedValue([summary()]);
+  renderList();
+  expect(await screen.findByRole("link", { name: /o2/ })).toHaveAttribute(
+    "href",
+    "/orders/o2"
+  );
+});
+
+it("shows an empty state rather than a blank page", async () => {
+  vi.spyOn(ordersApi, "listOrders").mockResolvedValue([]);
+  renderList();
+  expect(await screen.findByText(/no orders yet/i)).toBeInTheDocument();
+});
+
+// HttpError, not NetworkError: the query client retries network failures by design (five
+// bounded attempts), so a NetworkError here would be testing the retry policy, not the page.
+it("shows an error state when the store answers badly", async () => {
+  vi.spyOn(ordersApi, "listOrders").mockRejectedValue(new HttpError(500));
+  renderList();
+  expect(await screen.findByRole("alert")).toHaveTextContent("500");
+});

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -79,3 +79,27 @@ body {
   font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
 }
+
+/* The active step breathes. It is a class, not an inline style, so the reduced-motion rule
+   below can remove it without the component branching on a media query. */
+@keyframes tracker-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+.tracker-pulse {
+  animation: tracker-pulse 1.4s ease-in-out infinite;
+}
+
+/* Removed, not substituted — no slower pulse, no cross-fade. The step still reads as active
+   through aria-current, its glyph, its colour and its spelled-out condition. */
+@media (prefers-reduced-motion: reduce) {
+  .tracker-pulse {
+    animation: none;
+  }
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -103,3 +103,11 @@ body {
     animation: none;
   }
 }
+
+/* --color-focus existed from 8a and nothing referenced it, so the app was relying on whatever
+   ring the browser happened to draw. Keyboard focus is the one affordance a mouse user never
+   sees and a keyboard user cannot work without. */
+:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}

--- a/docker-compose.prod.example.yml
+++ b/docker-compose.prod.example.yml
@@ -47,3 +47,18 @@ services:
     environment:
       COOKIE_SECURE: "true" # cookies only over https once a TLS terminator is in front
     ports: ["8000:8000"]
+
+  # The storefront, defined only here: dev keeps the Vite dev server, because HMR is the reason
+  # it exists and containerising dev trades it for nothing. A service introduced by an overlay
+  # is still created, so no change to the base file is needed.
+  #
+  # Published, because it is the human entry point. The gateway keeps its own published port:
+  # the payment provider's webhook is an inbound call that does not pass through nginx.
+  web:
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
+    depends_on: [gateway]
+    ports: ["8080:80"]
+    restart: unless-stopped
+    profiles: ["app"]

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -78,3 +78,36 @@ on infra your local file might be missing, re-diff against
 `infra/postgres/init/01-databases.sql` runs once on first volume creation and
 creates a database per service. To re-run it, remove the volume:
 `docker compose down -v` (destroys all local data).
+
+## Storefront e2e (local only)
+
+Playwright drives three walks against a real stack. CI never runs them: the `quality` job has
+no compose stack, and standing up eight services plus two brokers for three browser walks is
+its own slice (8c spec §F4).
+
+```bash
+docker compose up -d                 # datastores AND the app profile must be healthy
+pnpm --filter @ecom/web dev          # or point WEB_URL at the nginx image
+pnpm --filter @ecom/web e2e
+```
+
+First run only: `pnpm --filter @ecom/web exec playwright install chromium`.
+
+Overridable: `WEB_URL` (default `http://localhost:5173`), `CATALOG_URL` (`:3004`),
+`INVENTORY_URL` (`:3001`).
+
+Two things about this suite are deliberate and worth knowing before changing it:
+
+- **It authenticates once**, in a setup project, and every walk reuses that storage state. The
+  gateway allows ten `/auth/*` requests a minute per apparent client, and a browser cannot
+  rotate `x-forwarded-for` the way `infra/scripts/drive-checkouts.ts` does — a suite that signed
+  in per walk spends its budget on authentication and then fails with 429s that read as
+  application bugs.
+- **Fixtures address Catalog and Inventory directly**, not through the gateway: creating a
+  product is an ADMIN mutation and Inventory is not mounted on the gateway at all. The
+  compensation walk needs a product priced so the total lands on `…01`, which is what makes the
+  simulated gateway decline (`services/payment/src/charge.ts`).
+
+A service image does **not** pick up source changes — the containers carry no volume mounts. After
+touching a service, `docker compose build <service> && docker compose up -d --no-deps <service>`
+before running the walks, or they will exercise the previous build.

--- a/docs/superpowers/plans/2026-08-04-phase-8c-tracker-polish.md
+++ b/docs/superpowers/plans/2026-08-04-phase-8c-tracker-polish.md
@@ -1,0 +1,1754 @@
+# Phase 8c — Order-pipeline tracker + polish — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the checkout saga visible — a live order tracker fed by SSE with a terminating polling fallback — and finish the storefront with order history, an accessibility pass, local e2e, and a packaged production build.
+
+**Architecture:** The stream writes into the React Query cache, so the page keeps one source of truth and the fallback is a flag on the same query. The four tracker steps are derived from the four `Order` statuses by one pure module. The Order service gains a list endpoint; the gateway is untouched.
+
+**Tech Stack:** React 19 + TanStack Query 5 + React Router 8 + Tailwind 4 (`apps/web`), Express + Prisma (`services/order`), zod contracts consumed as TypeScript source, Vitest (jsdom project) + Playwright, nginx for packaging.
+
+**Spec:** `docs/superpowers/specs/2026-08-04-phase-8c-tracker-polish-design.md` — read it before Task 1. Section references below (§A1, §B2, …) point into it.
+
+## Global Constraints
+
+- Every task ends green on `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — **lint included**, per 7c's lesson that CI caught lint errors no task check would.
+- Run tests from the repo root: `pnpm vitest run <path>`. The root `vitest.workspace.ts` gives `apps/web` its own jsdom project; the node projects must never inherit it.
+- Web tests live at `src/**/__tests__/<name>.test.ts(x)` — the glob in `apps/web/vitest.config.ts` is `src/**/*.test.{ts,tsx}`.
+- Integration tests that touch Postgres tag the rows they seed and delete them by DB query in `afterAll` (7d convention — see `services/order/src/__tests__/ownership.int.test.ts`).
+- Never commit `docker-compose.yml`, `.env*`, or anything under a config directory. Only `*.example.yml` files are committed.
+- Commit specific files. Never `git add -A`.
+- `POLL_INTERVAL_MS = 3000`, `MAX_STREAM_ERRORS = 3`, `ORDER_LIST_LIMIT = 50` — named constants, never literals at call sites.
+- The browser only ever calls same-origin `/api/*`. No gateway host in the bundle.
+
+## File structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `packages/contracts/src/http/order.ts` | `OrderSummarySchema`, `OrderListSchema`; cart schemas become strict | 1, 11 |
+| `services/order/src/app.ts` | `GET /orders` (list, caller-scoped, capped) | 1 |
+| `services/order/src/__tests__/order-list.int.test.ts` | proves scoping, ordering, cap, `itemCount` | 1 |
+| `apps/web/src/api/errors.ts` | `HttpError` carries an optional parsed body | 2 |
+| `apps/web/src/api/request.ts` | best-effort error-body read | 2 |
+| `apps/web/src/api/orders.ts` | `listOrders()`; `describeCheckoutFailure` names the product | 2, 7 |
+| `apps/web/src/order/saga-steps.ts` | the ONLY module that knows what a status implies | 3 |
+| `apps/web/src/api/stream.ts` | EventSource wrapper: named `status` events, injectable factory | 4 |
+| `apps/web/src/hooks/useOrderStream.ts` | the fallback ladder and the cache writes | 5 |
+| `apps/web/src/components/OrderTracker.tsx` | presentational pipeline | 6 |
+| `apps/web/src/routes/Order.tsx` | wires tracker + stream into the detail page | 6 |
+| `apps/web/src/routes/Orders.tsx` | order history | 7 |
+| `apps/web/src/components/Layout.tsx` | skip link, history nav link | 7, 8 |
+| `apps/web/playwright.config.ts`, `apps/web/e2e/*.spec.ts` | three local walks | 9 |
+| `apps/web/Dockerfile`, `apps/web/nginx.conf`, `docker-compose.prod.example.yml` | packaging | 10 |
+| `services/order/src/metrics.ts` | `SAGA_BUCKETS` boundaries near 1.5s and 2s | 11 |
+
+---
+
+### Task 1: `GET /orders` and the summary contract
+
+**Files:**
+
+- Modify: `packages/contracts/src/http/order.ts`
+- Modify: `services/order/src/app.ts` (add a route beside `GET /orders/:id` at :183)
+- Test: `services/order/src/__tests__/order-list.int.test.ts` (create)
+
+**Interfaces:**
+
+- Produces: `OrderSummarySchema`, `OrderListSchema`, `type OrderSummary` from `@ecom/contracts`; `GET /orders` → `200` array of `{id, status, totalPrice, itemCount, createdAt}`, `400` without `x-user-id`.
+- Consumes: nothing from earlier tasks.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `services/order/src/__tests__/order-list.int.test.ts`:
+
+```ts
+import { describe, it, expect, afterAll } from "vitest";
+import { randomUUID } from "crypto";
+import request from "supertest";
+import { OrderListSchema } from "@ecom/contracts";
+import { createApp } from "../app";
+import { prisma } from "../db";
+
+const app = createApp();
+
+// Tagged so afterAll can delete by query rather than an in-memory id list (7d convention).
+const TEST_TAG = "test-order-list-int";
+const tagged = () => `${TEST_TAG}-${randomUUID()}`;
+
+async function seedOrder(userId: string, lines: number, createdAt: Date) {
+  return prisma.order.create({
+    data: {
+      userId,
+      status: "PENDING",
+      totalPrice: 100 * lines,
+      createdAt,
+      items: {
+        create: Array.from({ length: lines }, () => ({
+          productId: `p_${randomUUID()}`,
+          quantity: 1,
+          unitPrice: 100,
+        })),
+      },
+    },
+  });
+}
+
+describe("order list (integration — needs compose up + migrated)", () => {
+  afterAll(async () => {
+    const seeded = await prisma.order.findMany({
+      where: { userId: { startsWith: TEST_TAG } },
+      select: { id: true },
+    });
+    const ids = seeded.map((o) => o.id);
+    if (ids.length > 0) {
+      await prisma.outbox.deleteMany({ where: { aggregateId: { in: ids } } });
+      await prisma.order.deleteMany({ where: { id: { in: ids } } });
+    }
+    await prisma.$disconnect();
+  });
+
+  it("returns only the caller's orders, newest first, with a line count", async () => {
+    const mine = tagged();
+    const theirs = tagged();
+    const older = await seedOrder(mine, 1, new Date("2026-08-01T00:00:00.000Z"));
+    const newer = await seedOrder(mine, 3, new Date("2026-08-02T00:00:00.000Z"));
+    await seedOrder(theirs, 2, new Date("2026-08-03T00:00:00.000Z"));
+
+    const res = await request(app).get("/orders").set("x-user-id", mine);
+
+    expect(res.status).toBe(200);
+    const parsed = OrderListSchema.parse(res.body);
+    expect(parsed.map((o) => o.id)).toEqual([newer.id, older.id]);
+    expect(parsed[0].itemCount).toBe(3);
+    expect(parsed[1].itemCount).toBe(1);
+  });
+
+  it("caps the list at 50", async () => {
+    const many = tagged();
+    for (let i = 0; i < 51; i++) {
+      await seedOrder(many, 1, new Date(2026, 0, 1, 0, 0, i));
+    }
+    const res = await request(app).get("/orders").set("x-user-id", many);
+    expect(res.body).toHaveLength(50);
+  });
+
+  it("rejects a request with no caller", async () => {
+    const res = await request(app).get("/orders");
+    expect(res.status).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `pnpm vitest run services/order/src/__tests__/order-list.int.test.ts`
+Expected: FAIL — `GET /orders` currently falls through to a 404, so `res.status` is 404 and `OrderListSchema` is not exported yet.
+
+- [ ] **Step 3: Add the contract**
+
+In `packages/contracts/src/http/order.ts`, below `OrderDetailSchema`:
+
+```ts
+// The history row. `itemCount` instead of the lines themselves: a list of 50 orders does not
+// need every line, and the detail endpoint already serves them.
+export const OrderSummarySchema = z.object({
+  id: z.string(),
+  status: OrderStatusSchema,
+  totalPrice: z.number().int(),
+  itemCount: z.number().int(),
+  createdAt: z.string(),
+});
+export type OrderSummary = z.infer<typeof OrderSummarySchema>;
+
+export const OrderListSchema = z.array(OrderSummarySchema);
+export type OrderList = z.infer<typeof OrderListSchema>;
+```
+
+- [ ] **Step 4: Add the route**
+
+In `services/order/src/app.ts`, immediately **before** `app.get("/orders/:id", …)` (:183):
+
+```ts
+// Caller-scoped history. Capped rather than paginated: a documented ceiling beats half a
+// pagination, and widening it later with a cursor is additive (spec §D2).
+const ORDER_LIST_LIMIT = 50;
+app.get("/orders", async (req, res) => {
+  const userId = userIdOf(req);
+  if (!userId) return res.status(400).json({ error: "missing x-user-id" });
+  try {
+    const orders = await prisma.order.findMany({
+      where: { userId },
+      orderBy: { createdAt: "desc" },
+      take: ORDER_LIST_LIMIT,
+      include: { _count: { select: { items: true } } },
+    });
+    res.json(
+      orders.map((o) => ({
+        id: o.id,
+        status: o.status,
+        totalPrice: o.totalPrice,
+        itemCount: o._count.items,
+        createdAt: o.createdAt.toISOString(),
+      }))
+    );
+  } catch {
+    log.error("order_list_failed", { traceId: req.traceId });
+    res.status(500).json({ error: "internal error" });
+  }
+});
+```
+
+- [ ] **Step 5: Run the test again**
+
+Run: `pnpm vitest run services/order/src/__tests__/order-list.int.test.ts`
+Expected: PASS, 3 tests. If the DB is not up: `docker compose up -d` and re-run.
+
+- [ ] **Step 6: Prove the gateway needs no change**
+
+Run: `grep -n "RULES" services/gateway/src/authz.ts` and confirm `GET /orders` matches no rule, then `grep -n 'app.use("/orders"' services/gateway/src/app.ts` and confirm the mount exists. Record both in the task report. **No gateway file is edited in this task** — if you find yourself editing one, stop and re-read spec §D1.
+
+- [ ] **Step 7: Gates and commit**
+
+```bash
+pnpm typecheck && pnpm lint && pnpm format:check
+git add packages/contracts/src/http/order.ts services/order/src/app.ts services/order/src/__tests__/order-list.int.test.ts
+git commit -m "feat(order): caller-scoped order history, capped at 50"
+```
+
+---
+
+### Task 2: `HttpError` carries a body, and checkout names the product
+
+**Files:**
+
+- Modify: `apps/web/src/api/errors.ts`
+- Modify: `apps/web/src/api/request.ts`
+- Modify: `apps/web/src/api/orders.ts`
+- Modify: `apps/web/src/routes/Cart.tsx` (call sites at :79 and :82)
+- Test: `apps/web/src/api/__tests__/request.test.ts` (extend), `apps/web/src/api/__tests__/orders.test.ts` (create)
+
+**Interfaces:**
+
+- Produces: `new HttpError(status, body?)` with `readonly body?: unknown`; `describeCheckoutFailure(e: unknown, nameFor?: (id: string) => string | undefined): string`.
+- Consumes: nothing from Task 1.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `apps/web/src/api/__tests__/request.test.ts`:
+
+```ts
+it("attaches a JSON error body to HttpError", async () => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(JSON.stringify({ error: "unpriced", productId: "p9" }), {
+      status: 422,
+      headers: { "content-type": "application/json" },
+    })
+  );
+  await expect(request("/api/orders", z.unknown(), { method: "POST" })).rejects.toMatchObject({
+    status: 422,
+    body: { productId: "p9" },
+  });
+});
+
+it("leaves body undefined when the error payload is not JSON", async () => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response("<html>502</html>", {
+      status: 502,
+      headers: { "content-type": "text/html" },
+    })
+  );
+  await expect(request("/api/orders", z.unknown())).rejects.toMatchObject({
+    status: 502,
+    body: undefined,
+  });
+});
+```
+
+The POST case needs an `XSRF-TOKEN` cookie; follow the cookie setup already used in that file.
+
+Create `apps/web/src/api/__tests__/orders.test.ts`:
+
+```ts
+import { describeCheckoutFailure } from "../orders";
+import { HttpError } from "../errors";
+
+it("names the unpriced product when the 422 body says which", () => {
+  const e = new HttpError(422, { error: "unpriced", productId: "p9" });
+  expect(describeCheckoutFailure(e, (id) => (id === "p9" ? "Widget" : undefined))).toContain(
+    "Widget"
+  );
+});
+
+it("falls back to a generic message when the body names no product", () => {
+  const e = new HttpError(422, {});
+  expect(describeCheckoutFailure(e, () => undefined)).toMatch(/no price/i);
+});
+
+it("still explains an empty cart", () => {
+  expect(describeCheckoutFailure(new HttpError(400))).toMatch(/empty/i);
+});
+```
+
+- [ ] **Step 2: Run them and watch them fail**
+
+Run: `pnpm vitest run apps/web/src/api/__tests__/request.test.ts apps/web/src/api/__tests__/orders.test.ts`
+Expected: FAIL — `HttpError` takes one argument, and `describeCheckoutFailure` takes one parameter.
+
+- [ ] **Step 3: Widen `HttpError`**
+
+In `apps/web/src/api/errors.ts`:
+
+```ts
+export class HttpError extends Error {
+  constructor(
+    readonly status: number,
+    // Parsed only when the response declared JSON, and only on a best-effort basis: a
+    // truncated or non-JSON error payload must not turn one failure into two. Everything
+    // still branches on `status`; `body` only ever adds detail to a message.
+    readonly body?: unknown
+  ) {
+    super(`the gateway answered ${status}`);
+    this.name = "HttpError";
+  }
+}
+```
+
+- [ ] **Step 4: Read the body in `request()`**
+
+In `apps/web/src/api/request.ts`, replace `if (!res.ok) throw new HttpError(res.status);` with:
+
+```ts
+if (!res.ok) throw new HttpError(res.status, await readErrorBody(res));
+```
+
+and add above `request`:
+
+```ts
+async function readErrorBody(res: Response): Promise<unknown> {
+  if (!res.headers.get("content-type")?.includes("application/json")) return undefined;
+  try {
+    return await res.json();
+  } catch {
+    return undefined;
+  }
+}
+```
+
+- [ ] **Step 5: Name the product**
+
+In `apps/web/src/api/orders.ts`:
+
+```ts
+export const listOrders = () => request(`${API}/orders`, OrderListSchema);
+
+// Order puts the offending productId in its 422 body; before 8c that detail was thrown away
+// with the body itself, so this said "one of these products" about a specific one.
+export function describeCheckoutFailure(
+  e: unknown,
+  nameFor: (id: string) => string | undefined = () => undefined
+): string {
+  if (e instanceof HttpError && e.status === 400)
+    return "Your cart is empty — it may have been placed in another tab.";
+  if (e instanceof HttpError && e.status === 422) {
+    const id =
+      typeof e.body === "object" && e.body !== null && "productId" in e.body
+        ? String((e.body as { productId: unknown }).productId)
+        : undefined;
+    const name = id ? nameFor(id) : undefined;
+    return name
+      ? `${name} has no price yet. Remove it and try again.`
+      : "One of these products has no price yet. Remove it and try again.";
+  }
+  return "Could not place the order. Try again.";
+}
+```
+
+Import `OrderListSchema` alongside the existing contract imports.
+
+- [ ] **Step 6: Pass the lookup at the call sites**
+
+In `apps/web/src/routes/Cart.tsx`, both calls become:
+
+```tsx
+setCheckoutError(describeCheckoutFailure(e, (id) => byId.get(id)?.name));
+```
+
+`byId` is already in scope (built at :30).
+
+- [ ] **Step 7: Run the tests**
+
+Run: `pnpm vitest run apps/web/src/api apps/web/src/routes/__tests__/Cart.test.tsx`
+Expected: PASS, no regression in the existing cart suite.
+
+- [ ] **Step 8: Gates and commit**
+
+```bash
+pnpm typecheck && pnpm lint && pnpm format:check
+git add apps/web/src/api/errors.ts apps/web/src/api/request.ts apps/web/src/api/orders.ts apps/web/src/routes/Cart.tsx apps/web/src/api/__tests__/request.test.ts apps/web/src/api/__tests__/orders.test.ts
+git commit -m "feat(web): error bodies reach the message that needed them"
+```
+
+---
+
+### Task 3: `saga-steps` — the only module that knows what a status implies
+
+**Files:**
+
+- Create: `apps/web/src/order/saga-steps.ts`
+- Test: `apps/web/src/order/__tests__/saga-steps.test.ts`
+
+**Interfaces:**
+
+- Produces:
+  ```ts
+  type StepKey = "placed" | "reserved" | "payment" | "confirmed";
+  type StepState = "done" | "active" | "failed" | "pending";
+  type Step = { key: StepKey; label: string; state: StepState };
+  type FailedAt = "PENDING" | "AWAITING_PAYMENT" | null;
+  function stepsFor(status: OrderStatus, failedAt?: FailedAt): Step[];
+  ```
+- Consumes: `OrderStatus` from `@ecom/contracts`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/order/__tests__/saga-steps.test.ts`:
+
+```ts
+import { stepsFor } from "../saga-steps";
+
+const stateOf = (status: Parameters<typeof stepsFor>[0], failedAt?: "PENDING" | "AWAITING_PAYMENT") =>
+  Object.fromEntries(stepsFor(status, failedAt ?? null).map((s) => [s.key, s.state]));
+
+it("PENDING means placed, and the reservation is in flight", () => {
+  expect(stateOf("PENDING")).toEqual({
+    placed: "done",
+    reserved: "active",
+    payment: "pending",
+    confirmed: "pending",
+  });
+});
+
+// The whole basis of the tracker: an order cannot reach AWAITING_PAYMENT unless the
+// reservation succeeded (services/order/src/transition.ts:14).
+it("AWAITING_PAYMENT proves the reservation succeeded", () => {
+  expect(stateOf("AWAITING_PAYMENT")).toEqual({
+    placed: "done",
+    reserved: "done",
+    payment: "active",
+    confirmed: "pending",
+  });
+});
+
+it("CONFIRMED completes every step", () => {
+  expect(stateOf("CONFIRMED")).toEqual({
+    placed: "done",
+    reserved: "done",
+    payment: "done",
+    confirmed: "done",
+  });
+});
+
+it("a cancellation observed during PENDING failed at the reservation", () => {
+  expect(stateOf("CANCELLED", "PENDING")).toEqual({
+    placed: "done",
+    reserved: "failed",
+    payment: "pending",
+    confirmed: "pending",
+  });
+});
+
+it("a cancellation observed during AWAITING_PAYMENT failed at the payment", () => {
+  expect(stateOf("CANCELLED", "AWAITING_PAYMENT")).toEqual({
+    placed: "done",
+    reserved: "done",
+    payment: "failed",
+    confirmed: "pending",
+  });
+});
+
+// Cold load: the status alone cannot say which leg failed, so the tracker names none.
+// Guessing "payment" would state a falsehood for every reservation-failed order.
+it("a cold-loaded cancellation blames no step", () => {
+  const states = stateOf("CANCELLED");
+  expect(Object.values(states)).not.toContain("failed");
+  expect(states.placed).toBe("done");
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `pnpm vitest run apps/web/src/order`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Create `apps/web/src/order/saga-steps.ts`:
+
+```ts
+import type { OrderStatus } from "@ecom/contracts";
+
+export type StepKey = "placed" | "reserved" | "payment" | "confirmed";
+export type StepState = "done" | "active" | "failed" | "pending";
+export type Step = { key: StepKey; label: string; state: StepState };
+
+// The status the tracker last saw before a terminal CANCELLED arrived. Null when the page was
+// loaded cold on an already-cancelled order — the one case where the failing leg is unknowable.
+export type FailedAt = "PENDING" | "AWAITING_PAYMENT" | null;
+
+const LABELS: Record<StepKey, string> = {
+  placed: "Order placed",
+  reserved: "Inventory reserved",
+  payment: "Payment",
+  confirmed: "Confirmed",
+};
+
+const ORDER: StepKey[] = ["placed", "reserved", "payment", "confirmed"];
+
+// The choreographed saga has more transitions than Order has statuses, and this is the only
+// module allowed to know how the two relate (spec §A1). Callers render what they are handed.
+function statesFor(status: OrderStatus, failedAt: FailedAt): Record<StepKey, StepState> {
+  switch (status) {
+    case "PENDING":
+      return { placed: "done", reserved: "active", payment: "pending", confirmed: "pending" };
+    case "AWAITING_PAYMENT":
+      return { placed: "done", reserved: "done", payment: "active", confirmed: "pending" };
+    case "CONFIRMED":
+      return { placed: "done", reserved: "done", payment: "done", confirmed: "done" };
+    case "CANCELLED":
+      if (failedAt === "PENDING")
+        return { placed: "done", reserved: "failed", payment: "pending", confirmed: "pending" };
+      if (failedAt === "AWAITING_PAYMENT")
+        return { placed: "done", reserved: "done", payment: "failed", confirmed: "pending" };
+      return { placed: "done", reserved: "pending", payment: "pending", confirmed: "pending" };
+  }
+}
+
+export function stepsFor(status: OrderStatus, failedAt: FailedAt = null): Step[] {
+  const states = statesFor(status, failedAt);
+  return ORDER.map((key) => ({ key, label: LABELS[key], state: states[key] }));
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `pnpm vitest run apps/web/src/order`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Gates and commit**
+
+```bash
+pnpm typecheck && pnpm lint && pnpm format:check
+git add apps/web/src/order/saga-steps.ts apps/web/src/order/__tests__/saga-steps.test.ts
+git commit -m "feat(web): derive the saga's four steps from its four statuses"
+```
+
+---
+
+### Task 4: `stream.ts` — a named SSE event behind an injectable factory
+
+**Files:**
+
+- Create: `apps/web/src/api/stream.ts`
+- Test: `apps/web/src/api/__tests__/stream.test.ts`
+
+**Interfaces:**
+
+- Produces:
+  ```ts
+  type StatusFrame = { orderId: string; status: OrderStatus };
+  type EventSourceLike = {
+    addEventListener(type: string, fn: (e: { data?: string }) => void): void;
+    close(): void;
+  };
+  type EventSourceFactory = (url: string) => EventSourceLike;
+  function openOrderStream(
+    orderId: string,
+    handlers: { onFrame: (f: StatusFrame) => void; onError: () => void },
+    opts?: { create?: EventSourceFactory }
+  ): { close: () => void };
+  ```
+- Consumes: `OrderStatusSchema` from `@ecom/contracts`.
+
+**Read first:** spec §B3. The service writes `event: status\ndata: {...}` (`services/order/src/app.ts:241`). `EventSource` routes a **named** event only to `addEventListener("status", …)`; `onmessage` fires for unnamed frames and would never fire here.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/api/__tests__/stream.test.ts`:
+
+```ts
+import { openOrderStream } from "../stream";
+
+type Listener = (e: { data?: string }) => void;
+
+// A fake that behaves like the real thing in the one way that matters: it delivers the
+// service's frames as a NAMED "status" event. A fake that called onmessage instead would make
+// every test here pass against a page that receives nothing.
+function fakeEventSource() {
+  const listeners = new Map<string, Listener[]>();
+  let closed = false;
+  const es = {
+    addEventListener(type: string, fn: Listener) {
+      listeners.set(type, [...(listeners.get(type) ?? []), fn]);
+    },
+    close() {
+      closed = true;
+    },
+  };
+  return {
+    create: (_url: string) => es,
+    emit: (type: string, data?: string) =>
+      (listeners.get(type) ?? []).forEach((fn) => fn({ data })),
+    isClosed: () => closed,
+  };
+}
+
+// Captured by the factory wrapper in the URL test below.
+let _seen = "";
+
+it("delivers a named status frame", () => {
+  const fake = fakeEventSource();
+  const frames: unknown[] = [];
+  openOrderStream("o1", { onFrame: (f) => frames.push(f), onError: () => {} }, {
+    create: (url) => {
+      _seen = url;
+      return fake.create(url);
+    },
+  });
+  fake.emit("status", JSON.stringify({ orderId: "o1", status: "AWAITING_PAYMENT" }));
+  expect(frames).toEqual([{ orderId: "o1", status: "AWAITING_PAYMENT" }]);
+});
+
+it("subscribes same-origin under /api", () => {
+  const fake = fakeEventSource();
+  openOrderStream("o1", { onFrame: () => {}, onError: () => {} }, {
+    create: (url) => {
+      _seen = url;
+      return fake.create(url);
+    },
+  });
+  expect(_seen).toBe("/api/orders/o1/stream");
+});
+
+it("ignores a frame that is not a valid status", () => {
+  const fake = fakeEventSource();
+  const frames: unknown[] = [];
+  openOrderStream("o1", { onFrame: (f) => frames.push(f), onError: () => {} }, {
+    create: fake.create,
+  });
+  fake.emit("status", JSON.stringify({ orderId: "o1", status: "WAT" }));
+  fake.emit("status", "not json at all");
+  expect(frames).toEqual([]);
+});
+
+it("reports errors and closes on demand", () => {
+  const fake = fakeEventSource();
+  let errors = 0;
+  const handle = openOrderStream("o1", { onFrame: () => {}, onError: () => errors++ }, {
+    create: fake.create,
+  });
+  fake.emit("error");
+  handle.close();
+  expect(errors).toBe(1);
+  expect(fake.isClosed()).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `pnpm vitest run apps/web/src/api/__tests__/stream.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Create `apps/web/src/api/stream.ts`:
+
+```ts
+import { OrderStatusSchema } from "@ecom/contracts";
+import type { OrderStatus } from "@ecom/contracts";
+import { z } from "zod";
+
+export type StatusFrame = { orderId: string; status: OrderStatus };
+
+const FrameSchema = z.object({ orderId: z.string(), status: OrderStatusSchema });
+
+// Structural, not `EventSource`: the constructor is undefined in the test environment (jsdom
+// does not implement it and Node 22 has no global), so the type cannot come from the DOM lib
+// at runtime and the factory must be injectable.
+export type EventSourceLike = {
+  addEventListener(type: string, fn: (e: { data?: string }) => void): void;
+  close(): void;
+};
+export type EventSourceFactory = (url: string) => EventSourceLike;
+
+const defaultCreate: EventSourceFactory = (url) =>
+  new EventSource(url) as unknown as EventSourceLike;
+
+export function openOrderStream(
+  orderId: string,
+  handlers: { onFrame: (f: StatusFrame) => void; onError: () => void },
+  opts: { create?: EventSourceFactory } = {}
+): { close: () => void } {
+  const create = opts.create ?? defaultCreate;
+  // Same-origin under /api, so the session cookie rides automatically — EventSource cannot
+  // set headers, which is why the gateway authenticates this stream from the cookie.
+  const es = create(`/api/orders/${encodeURIComponent(orderId)}/stream`);
+
+  // NAMED event. The service writes `event: status`, and onmessage would never fire.
+  es.addEventListener("status", (e) => {
+    let raw: unknown;
+    try {
+      raw = JSON.parse(e.data ?? "");
+    } catch {
+      return;
+    }
+    const parsed = FrameSchema.safeParse(raw);
+    // A frame that does not match the contract is dropped rather than thrown: the stream is a
+    // progress indicator, and the query underneath it remains the authority.
+    if (parsed.success) handlers.onFrame(parsed.data);
+  });
+
+  es.addEventListener("error", () => handlers.onError());
+
+  return { close: () => es.close() };
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `pnpm vitest run apps/web/src/api/__tests__/stream.test.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Prove the test can fail**
+
+Temporarily change `addEventListener("status", …)` to `addEventListener("message", …)`, re-run, and confirm the first test FAILS. Revert. Record the observation in the task report — this is the mutation check the spec asks for (§B3).
+
+- [ ] **Step 6: Gates and commit**
+
+```bash
+pnpm typecheck && pnpm lint && pnpm format:check
+git add apps/web/src/api/stream.ts apps/web/src/api/__tests__/stream.test.ts
+git commit -m "feat(web): SSE frames, read as the named event they are"
+```
+
+---
+
+### Task 5: `useOrderStream` — the ladder and the cache writes
+
+**Files:**
+
+- Create: `apps/web/src/hooks/useOrderStream.ts`
+- Test: `apps/web/src/hooks/__tests__/useOrderStream.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `openOrderStream`, `EventSourceFactory` (Task 4); `FailedAt` (Task 3); `refreshSession` from `../api/refresh`.
+- Produces:
+  ```ts
+  const POLL_INTERVAL_MS = 3000;
+  const MAX_STREAM_ERRORS = 3;
+  function useOrderStream(
+    orderId: string,
+    opts?: { create?: EventSourceFactory }
+  ): { polling: boolean; failedAt: FailedAt };
+  ```
+
+**Read first:** spec §B1 and §B2. Rung 1 **closes, refreshes, reopens** — leaving the stream open lets its own ~3s reconnect race the refresh.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/hooks/__tests__/useOrderStream.test.tsx`:
+
+```tsx
+import { QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { makeQueryClient } from "../../api/queryClient";
+import * as refreshApi from "../../api/refresh";
+import { useOrderStream } from "../useOrderStream";
+
+type Listener = (e: { data?: string }) => void;
+
+function harness() {
+  const instances: Array<{ listeners: Map<string, Listener[]>; closed: boolean }> = [];
+  const create = () => {
+    const inst = { listeners: new Map<string, Listener[]>(), closed: false };
+    instances.push(inst);
+    return {
+      addEventListener(type: string, fn: Listener) {
+        inst.listeners.set(type, [...(inst.listeners.get(type) ?? []), fn]);
+      },
+      close() {
+        inst.closed = true;
+      },
+    };
+  };
+  const emit = (i: number, type: string, data?: string) =>
+    (instances[i].listeners.get(type) ?? []).forEach((fn) => fn({ data }));
+  return { create, emit, instances };
+}
+
+const wrapper = (client = makeQueryClient()) =>
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+
+afterEach(() => vi.restoreAllMocks());
+
+it("advances an existing cached order and never creates one", async () => {
+  const client = makeQueryClient();
+  const h = harness();
+  client.setQueryData(["order", "o1"], {
+    id: "o1",
+    userId: "u1",
+    status: "PENDING",
+    totalPrice: 100,
+    items: [{ productId: "p1", quantity: 1, unitPrice: 100 }],
+    createdAt: "2026-08-04T00:00:00.000Z",
+  });
+  renderHook(() => useOrderStream("o1", { create: h.create }), { wrapper: wrapper(client) });
+  act(() => h.emit(0, "status", JSON.stringify({ orderId: "o1", status: "AWAITING_PAYMENT" })));
+  await waitFor(() =>
+    expect((client.getQueryData(["order", "o1"]) as { status: string }).status).toBe(
+      "AWAITING_PAYMENT"
+    )
+  );
+});
+
+it("drops a frame that arrives before the order is cached", async () => {
+  const client = makeQueryClient();
+  const h = harness();
+  renderHook(() => useOrderStream("o1", { create: h.create }), { wrapper: wrapper(client) });
+  act(() => h.emit(0, "status", JSON.stringify({ orderId: "o1", status: "CONFIRMED" })));
+  expect(client.getQueryData(["order", "o1"])).toBeUndefined();
+});
+
+it("closes, refreshes once, and reopens on the first error", async () => {
+  const h = harness();
+  const refresh = vi.spyOn(refreshApi, "refreshSession").mockResolvedValue(true);
+  renderHook(() => useOrderStream("o1", { create: h.create }), { wrapper: wrapper() });
+  act(() => h.emit(0, "error"));
+  await waitFor(() => expect(h.instances).toHaveLength(2));
+  expect(h.instances[0].closed).toBe(true);
+  expect(refresh).toHaveBeenCalledTimes(1);
+});
+
+it("falls back to polling on the third error and not before", async () => {
+  const h = harness();
+  vi.spyOn(refreshApi, "refreshSession").mockResolvedValue(true);
+  const { result } = renderHook(() => useOrderStream("o1", { create: h.create }), {
+    wrapper: wrapper(),
+  });
+  act(() => h.emit(0, "error"));
+  await waitFor(() => expect(h.instances).toHaveLength(2));
+  act(() => h.emit(1, "error"));
+  expect(result.current.polling).toBe(false);
+  act(() => h.emit(1, "error"));
+  await waitFor(() => expect(result.current.polling).toBe(true));
+  expect(h.instances[1].closed).toBe(true);
+});
+
+it("remembers the status it was in when a cancellation arrived", async () => {
+  const client = makeQueryClient();
+  const h = harness();
+  client.setQueryData(["order", "o1"], { id: "o1", status: "PENDING", items: [] });
+  const { result } = renderHook(() => useOrderStream("o1", { create: h.create }), {
+    wrapper: wrapper(client),
+  });
+  act(() => h.emit(0, "status", JSON.stringify({ orderId: "o1", status: "AWAITING_PAYMENT" })));
+  act(() => h.emit(0, "status", JSON.stringify({ orderId: "o1", status: "CANCELLED" })));
+  await waitFor(() => expect(result.current.failedAt).toBe("AWAITING_PAYMENT"));
+});
+
+it("stops everything on a terminal frame", async () => {
+  const h = harness();
+  const { result } = renderHook(() => useOrderStream("o1", { create: h.create }), {
+    wrapper: wrapper(),
+  });
+  act(() => h.emit(0, "status", JSON.stringify({ orderId: "o1", status: "CONFIRMED" })));
+  await waitFor(() => expect(h.instances[0].closed).toBe(true));
+  expect(result.current.polling).toBe(false);
+});
+
+it("closes the stream on unmount", () => {
+  const h = harness();
+  const { unmount } = renderHook(() => useOrderStream("o1", { create: h.create }), {
+    wrapper: wrapper(),
+  });
+  unmount();
+  expect(h.instances[0].closed).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `pnpm vitest run apps/web/src/hooks`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Create `apps/web/src/hooks/useOrderStream.ts`:
+
+```ts
+import { useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import type { OrderDetail, OrderStatus } from "@ecom/contracts";
+import { openOrderStream, type EventSourceFactory } from "../api/stream";
+import { refreshSession } from "../api/refresh";
+import type { FailedAt } from "../order/saga-steps";
+
+// Chosen against the saga_duration p(99)<5000 threshold in k6/checkout.js:21.
+export const POLL_INTERVAL_MS = 3000;
+export const MAX_STREAM_ERRORS = 3;
+
+const isTerminal = (s: OrderStatus) => s === "CONFIRMED" || s === "CANCELLED";
+
+export function useOrderStream(
+  orderId: string,
+  opts: { create?: EventSourceFactory } = {}
+): { polling: boolean; failedAt: FailedAt } {
+  const qc = useQueryClient();
+  const [polling, setPolling] = useState(false);
+  const [failedAt, setFailedAt] = useState<FailedAt>(null);
+  const create = opts.create;
+
+  // Refs, not state: the ladder must not re-render the page, and a stale closure over the
+  // error count would let a burst of errors each read zero.
+  const lastStatus = useRef<OrderStatus | null>(null);
+  const errors = useRef(0);
+  const refreshing = useRef(false);
+  const handle = useRef<{ close: () => void } | null>(null);
+  const stopped = useRef(false);
+
+  useEffect(() => {
+    stopped.current = false;
+    errors.current = 0;
+
+    const stop = () => {
+      stopped.current = true;
+      handle.current?.close();
+      handle.current = null;
+    };
+
+    const open = () => {
+      if (stopped.current) return;
+      handle.current = openOrderStream(
+        orderId,
+        {
+          onFrame: (f) => {
+            // Advance an existing order; never materialise one. The stream sends the current
+            // status on subscribe, so a frame routinely beats GET /orders/:id — and a
+            // {status}-only object would render an order with no lines (spec §B1).
+            qc.setQueryData<OrderDetail>(["order", orderId], (old) =>
+              old ? { ...old, status: f.status } : old
+            );
+            if (f.status === "CANCELLED" && lastStatus.current)
+              setFailedAt(lastStatus.current === "CONFIRMED" ? null : lastStatus.current);
+            lastStatus.current = f.status;
+            if (isTerminal(f.status)) {
+              setPolling(false);
+              stop();
+            }
+          },
+          onError: () => {
+            if (stopped.current || refreshing.current) return;
+            errors.current += 1;
+            if (errors.current === 1) {
+              // Close BEFORE refreshing: EventSource reconnects on its own ~3s timer, and that
+              // attempt would 401 again mid-refresh and spend a second rung (spec §B2).
+              refreshing.current = true;
+              handle.current?.close();
+              handle.current = null;
+              void refreshSession().finally(() => {
+                refreshing.current = false;
+                open();
+              });
+              return;
+            }
+            if (errors.current >= MAX_STREAM_ERRORS) {
+              stop();
+              setPolling(true);
+            }
+          },
+        },
+        create ? { create } : {}
+      );
+    };
+
+    open();
+    return stop;
+  }, [orderId, qc, create]);
+
+  return { polling, failedAt };
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `pnpm vitest run apps/web/src/hooks`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Gates and commit**
+
+```bash
+pnpm typecheck && pnpm lint && pnpm format:check
+git add apps/web/src/hooks/useOrderStream.ts apps/web/src/hooks/__tests__/useOrderStream.test.tsx
+git commit -m "feat(web): a fallback ladder that terminates"
+```
+
+---
+
+### Task 6: The tracker, on the order page
+
+**Files:**
+
+- Create: `apps/web/src/components/OrderTracker.tsx`
+- Modify: `apps/web/src/routes/Order.tsx`
+- Modify: `apps/web/src/styles.css` (the pulse and its reduced-motion rule)
+- Test: `apps/web/src/components/__tests__/OrderTracker.test.tsx`, extend `apps/web/src/routes/__tests__/Order.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `stepsFor`, `Step`, `FailedAt` (Task 3); `useOrderStream`, `POLL_INTERVAL_MS` (Task 5).
+- Produces: `<OrderTracker status={OrderStatus} failedAt={FailedAt} />`.
+
+- [ ] **Step 1: Write the failing component test**
+
+Create `apps/web/src/components/__tests__/OrderTracker.test.tsx`:
+
+```tsx
+import { render, screen, within } from "@testing-library/react";
+import { OrderTracker } from "../OrderTracker";
+
+it("marks the current step and announces it politely", () => {
+  render(<OrderTracker status="AWAITING_PAYMENT" failedAt={null} />);
+  const current = screen.getByRole("listitem", { current: "step" });
+  expect(within(current).getByText("Payment")).toBeInTheDocument();
+  expect(screen.getByRole("status")).toHaveTextContent(/payment/i);
+});
+
+it("labels every step in text, so colour is never the only channel", () => {
+  render(<OrderTracker status="PENDING" failedAt={null} />);
+  for (const label of ["Order placed", "Inventory reserved", "Payment", "Confirmed"])
+    expect(screen.getByText(label)).toBeInTheDocument();
+  // The state is readable without seeing the colour.
+  expect(screen.getByText("Inventory reserved").closest("li")).toHaveTextContent(/in progress/i);
+});
+
+it("shows the compensation path when the failure was observed", () => {
+  render(<OrderTracker status="CANCELLED" failedAt="AWAITING_PAYMENT" />);
+  expect(screen.getByText("Payment").closest("li")).toHaveTextContent(/failed/i);
+});
+
+it("blames no step on a cold-loaded cancellation", () => {
+  render(<OrderTracker status="CANCELLED" failedAt={null} />);
+  expect(screen.queryByText(/failed/i)).not.toBeInTheDocument();
+  expect(screen.getByRole("status")).toHaveTextContent(/cancelled/i);
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `pnpm vitest run apps/web/src/components/__tests__/OrderTracker.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the tracker**
+
+Create `apps/web/src/components/OrderTracker.tsx`:
+
+```tsx
+import type { OrderStatus } from "@ecom/contracts";
+import { stepsFor, type FailedAt, type Step } from "../order/saga-steps";
+
+// Colour encodes saga state per the design language — so every step ALSO carries a glyph and a
+// text state, and the pipeline stays readable in greyscale and to a screen reader.
+const GLYPH: Record<Step["state"], string> = {
+  done: "✓",
+  active: "●",
+  failed: "✕",
+  pending: "○",
+};
+const STATE_TEXT: Record<Step["state"], string> = {
+  done: "done",
+  active: "in progress",
+  failed: "failed",
+  pending: "waiting",
+};
+const TONE: Record<Step["state"], string> = {
+  done: "text-[color:var(--color-ok)]",
+  active: "text-[color:var(--color-pending)]",
+  failed: "text-[color:var(--color-danger)]",
+  pending: "text-[color:var(--color-muted)]",
+};
+
+function announce(status: OrderStatus, steps: Step[]): string {
+  if (status === "CONFIRMED") return "Order confirmed";
+  if (status === "CANCELLED") {
+    const failed = steps.find((s) => s.state === "failed");
+    return failed ? `Order cancelled — ${failed.label} failed` : "Order cancelled";
+  }
+  const active = steps.find((s) => s.state === "active");
+  return active ? `${active.label} in progress` : "Order placed";
+}
+
+export function OrderTracker({
+  status,
+  failedAt,
+}: {
+  status: OrderStatus;
+  failedAt: FailedAt;
+}) {
+  const steps = stepsFor(status, failedAt);
+  return (
+    <div>
+      <ol className="flex flex-col gap-3 sm:flex-row sm:items-start sm:gap-6">
+        {steps.map((s) => (
+          <li
+            key={s.key}
+            aria-current={s.state === "active" ? "step" : undefined}
+            className="flex items-center gap-2 sm:flex-1"
+          >
+            <span aria-hidden="true" className={`${TONE[s.state]} ${s.state === "active" ? "tracker-pulse" : ""}`}>
+              {GLYPH[s.state]}
+            </span>
+            <span className="datum text-sm">{s.label}</span>
+            <span className="sr-only">{STATE_TEXT[s.state]}</span>
+          </li>
+        ))}
+      </ol>
+      {/* Polite, not assertive: the saga can produce three transitions in a few seconds, and
+          none of them is an interruption. */}
+      <p role="status" aria-live="polite" className="sr-only">
+        {announce(status, steps)}
+      </p>
+    </div>
+  );
+}
+```
+
+If `--color-ok`, `--color-pending`, `--color-danger` are not already declared in the `@theme static` block of `apps/web/src/styles.css`, add them there — **`@theme` is tree-shaken and arbitrary values do not count as references**, which is 8a's trap.
+
+- [ ] **Step 4: Add the pulse and its reduced-motion rule**
+
+In `apps/web/src/styles.css`:
+
+```css
+@keyframes tracker-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+.tracker-pulse {
+  animation: tracker-pulse 1.4s ease-in-out infinite;
+}
+
+/* Removed, not substituted: no slower pulse, no cross-fade. The step still reads as active
+   through aria-current, its glyph and its colour. */
+@media (prefers-reduced-motion: reduce) {
+  .tracker-pulse {
+    animation: none;
+  }
+}
+```
+
+- [ ] **Step 5: Run the component test**
+
+Run: `pnpm vitest run apps/web/src/components/__tests__/OrderTracker.test.tsx`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 6: Wire it into the order page**
+
+In `apps/web/src/routes/Order.tsx`: call the hook, feed the query, render the tracker.
+
+```tsx
+const { polling, failedAt } = useOrderStream(id);
+const order = useQuery({
+  queryKey: ["order", id],
+  queryFn: () => getOrder(id),
+  refetchInterval: polling ? POLL_INTERVAL_MS : false,
+});
+```
+
+Replace the `<h1>Order placed</h1>` heading with `<h1>Order</h1>` (it is reached from history too — spec §H), keep the `<Badge>`, and render `<OrderTracker status={order.data.status} failedAt={failedAt} />` directly beneath the heading row. Stop polling automatically: the hook clears `polling` on a terminal frame, and a terminal status also ends the stream, so add
+
+```tsx
+refetchInterval: polling && !isTerminalStatus(order.data?.status) ? POLL_INTERVAL_MS : false,
+```
+
+with a local `const isTerminalStatus = (s?: OrderStatus) => s === "CONFIRMED" || s === "CANCELLED";` — the fallback transport must stop on its own, because in polling mode no frame will ever arrive to stop it.
+
+- [ ] **Step 7: Extend the route test**
+
+Append to `apps/web/src/routes/__tests__/Order.test.tsx`:
+
+```tsx
+it("renders the pipeline for the order's status", async () => {
+  vi.spyOn(ordersApi, "getOrder").mockResolvedValue(detail({ status: "AWAITING_PAYMENT" }));
+  vi.spyOn(productsApi, "listProducts").mockResolvedValue([]);
+  renderAt("o1");
+  expect(await screen.findByText("Inventory reserved")).toBeInTheDocument();
+  expect(screen.getByRole("listitem", { current: "step" })).toHaveTextContent("Payment");
+});
+```
+
+The route now calls `useOrderStream`, which constructs a real `EventSource` by default — undefined in jsdom. Pass a no-op factory through the hook's default only in the test by stubbing the module:
+
+```tsx
+vi.mock("../../hooks/useOrderStream", () => ({
+  useOrderStream: () => ({ polling: false, failedAt: null }),
+  POLL_INTERVAL_MS: 3000,
+}));
+```
+
+- [ ] **Step 8: Run the route suite**
+
+Run: `pnpm vitest run apps/web/src/routes/__tests__/Order.test.tsx`
+Expected: PASS, existing tests plus the new one.
+
+- [ ] **Step 9: Gates and commit**
+
+```bash
+pnpm typecheck && pnpm lint && pnpm format:check
+git add apps/web/src/components/OrderTracker.tsx apps/web/src/components/__tests__/OrderTracker.test.tsx apps/web/src/routes/Order.tsx apps/web/src/routes/__tests__/Order.test.tsx apps/web/src/styles.css
+git commit -m "feat(web): the order pipeline, live"
+```
+
+---
+
+### Task 7: Order history
+
+**Files:**
+
+- Create: `apps/web/src/routes/Orders.tsx`
+- Modify: `apps/web/src/App.tsx`, `apps/web/src/components/Layout.tsx`
+- Test: `apps/web/src/routes/__tests__/Orders.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `listOrders` (Task 2), `OrderSummary` (Task 1).
+- Produces: the `/orders` route.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/routes/__tests__/Orders.test.tsx`:
+
+```tsx
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { makeQueryClient } from "../../api/queryClient";
+import { NetworkError } from "../../api/errors";
+import * as ordersApi from "../../api/orders";
+import { Orders } from "../Orders";
+
+function renderList() {
+  const router = createMemoryRouter(
+    [
+      { path: "/orders", element: <Orders /> },
+      { path: "/orders/:id", element: <div>detail</div> },
+    ],
+    { initialEntries: ["/orders"] }
+  );
+  return render(
+    <QueryClientProvider client={makeQueryClient()}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  );
+}
+afterEach(() => vi.restoreAllMocks());
+
+it("lists the caller's orders with their status and total", async () => {
+  vi.spyOn(ordersApi, "listOrders").mockResolvedValue([
+    {
+      id: "o2",
+      status: "CONFIRMED",
+      totalPrice: 2500,
+      itemCount: 2,
+      createdAt: "2026-08-04T10:00:00.000Z",
+    },
+  ]);
+  renderList();
+  expect(await screen.findByText("o2")).toBeInTheDocument();
+  expect(screen.getByText("CONFIRMED")).toBeInTheDocument();
+  expect(screen.getByText("$25.00")).toBeInTheDocument();
+  expect(screen.getByText(/2 items/)).toBeInTheDocument();
+});
+
+it("shows an empty state rather than a blank page", async () => {
+  vi.spyOn(ordersApi, "listOrders").mockResolvedValue([]);
+  renderList();
+  expect(await screen.findByText(/no orders yet/i)).toBeInTheDocument();
+});
+
+it("shows an error state when the gateway cannot be reached", async () => {
+  vi.spyOn(ordersApi, "listOrders").mockRejectedValue(new NetworkError(new Error("down")));
+  renderList();
+  expect(await screen.findByText(/could not be reached/i)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `pnpm vitest run apps/web/src/routes/__tests__/Orders.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the page**
+
+Create `apps/web/src/routes/Orders.tsx`:
+
+```tsx
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router";
+import { listOrders } from "../api/orders";
+import { Badge } from "../components/Badge";
+import { EmptyState } from "../components/EmptyState";
+import { ErrorState } from "../components/ErrorState";
+import { Price } from "../components/Price";
+import { Skeleton } from "../components/Skeleton";
+
+export function Orders() {
+  const orders = useQuery({ queryKey: ["orders"], queryFn: listOrders });
+
+  if (orders.isPending) return <Skeleton />;
+  if (orders.error) return <ErrorState error={orders.error} />;
+  if (orders.data.length === 0)
+    return <EmptyState>No orders yet — placing one starts the pipeline.</EmptyState>;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h1 className="text-2xl">Your orders</h1>
+      <ul className="flex flex-col">
+        {orders.data.map((o) => (
+          <li key={o.id} className="border-b border-[color:var(--color-line)] py-3">
+            <Link to={`/orders/${o.id}`} className="flex items-center justify-between gap-4">
+              <span className="datum text-sm">{o.id}</span>
+              <span className="datum text-xs text-[color:var(--color-muted)]">
+                {o.itemCount} items
+              </span>
+              <Badge>{o.status}</Badge>
+              <Price minorUnits={o.totalPrice} />
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+```
+
+Match `EmptyState`/`ErrorState`'s real prop signatures — read those two components before writing this.
+
+- [ ] **Step 4: Register the route and the nav link**
+
+In `apps/web/src/App.tsx`, beside the existing `/orders/:id` entry — **`/orders` must be listed before `/orders/:id`** is not required by React Router 8 (exact paths win), but keep them adjacent for readability:
+
+```tsx
+{
+  path: "/orders",
+  element: (
+    <RequireAuth>
+      <Orders />
+    </RequireAuth>
+  ),
+},
+```
+
+In `apps/web/src/components/Layout.tsx`, inside the `<nav>` and only when the session is authenticated, add `<Link to="/orders" className="datum text-sm">Orders</Link>` next to the cart link.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `pnpm vitest run apps/web/src/routes`
+Expected: PASS, including the untouched suites.
+
+- [ ] **Step 6: Gates and commit**
+
+```bash
+pnpm typecheck && pnpm lint && pnpm format:check
+git add apps/web/src/routes/Orders.tsx apps/web/src/routes/__tests__/Orders.test.tsx apps/web/src/App.tsx apps/web/src/components/Layout.tsx
+git commit -m "feat(web): order history"
+```
+
+---
+
+### Task 8: The accessibility sweep
+
+**Files:**
+
+- Modify: `apps/web/src/components/Layout.tsx`, `apps/web/src/styles.css`
+- Modify: `apps/web/src/routes/Login.tsx`, `Register.tsx`, `Cart.tsx` as the audit requires
+- Test: `apps/web/src/components/__tests__/Layout.test.tsx` (create)
+
+**Scope is closed** (spec §C): skip link, heading order, visible focus, labelled inputs. Anything else found is a note for the merge record, not a change.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/__tests__/Layout.test.tsx`:
+
+```tsx
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { makeQueryClient } from "../../api/queryClient";
+import * as sessionApi from "../../api/session";
+import { Layout } from "../Layout";
+
+function renderLayout() {
+  const router = createMemoryRouter([{ element: <Layout />, children: [{ index: true, element: <h1>Home</h1> }] }], {
+    initialEntries: ["/"],
+  });
+  return render(
+    <QueryClientProvider client={makeQueryClient()}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  );
+}
+afterEach(() => vi.restoreAllMocks());
+
+it("offers a skip link that targets the main region", async () => {
+  vi.spyOn(sessionApi, "probeSession").mockResolvedValue({ authenticated: false, cart: null });
+  renderLayout();
+  const skip = screen.getByRole("link", { name: /skip to content/i });
+  expect(skip).toHaveAttribute("href", "#main");
+  expect(screen.getByRole("main")).toHaveAttribute("id", "main");
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `pnpm vitest run apps/web/src/components/__tests__/Layout.test.tsx`
+Expected: FAIL — no skip link.
+
+- [ ] **Step 3: Add the skip link and the main landmark**
+
+In `apps/web/src/components/Layout.tsx`, as the first child of the wrapper:
+
+```tsx
+<a
+  href="#main"
+  className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-[color:var(--color-surface)] focus:px-3 focus:py-2"
+>
+  Skip to content
+</a>
+```
+
+and give the element wrapping `<Outlet />` `id="main"` plus `role`-implying `<main>`.
+
+- [ ] **Step 4: Audit the three forms**
+
+Run the app (`pnpm --filter @ecom/web dev`) and check with the keyboard alone: every input in Login, Register and Cart reachable and announced by a `<label htmlFor>` (not a placeholder), a visible focus ring on every interactive element, and one `<h1>` per route with no skipped levels. Fix what fails; change nothing that passes.
+
+- [ ] **Step 5: Run the whole web suite**
+
+Run: `pnpm vitest run apps/web`
+Expected: PASS.
+
+- [ ] **Step 6: Gates and commit**
+
+```bash
+pnpm typecheck && pnpm lint && pnpm format:check
+git add apps/web/src/components/Layout.tsx apps/web/src/components/__tests__/Layout.test.tsx apps/web/src/styles.css apps/web/src/routes
+git commit -m "feat(web): skip link, labelled inputs, visible focus"
+```
+
+---
+
+### Task 9: Playwright, locally
+
+**Files:**
+
+- Create: `apps/web/playwright.config.ts`, `apps/web/e2e/checkout.spec.ts`, `apps/web/e2e/compensation.spec.ts`, `apps/web/e2e/session-expiry.spec.ts`, `apps/web/e2e/fixtures.ts`
+- Modify: `apps/web/package.json` (devDependency + `e2e` script), `docs/infra.md` (how to run)
+
+**Preconditions:** a full stack is up (`docker compose up -d`), migrations applied, and an admin credential available for `POST /products`. The suite is **not** wired into CI (spec §F4).
+
+- [ ] **Step 1: Install and configure**
+
+```bash
+pnpm --filter @ecom/web add -D @playwright/test
+pnpm --filter @ecom/web exec playwright install chromium
+```
+
+Create `apps/web/playwright.config.ts`:
+
+```ts
+import { defineConfig } from "@playwright/test";
+
+// Local only. CI's quality job has no compose stack, and standing eight services plus two
+// brokers up to run three browser walks is its own slice (spec §F4).
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  use: { baseURL: process.env.WEB_URL ?? "http://localhost:5173", trace: "on-first-retry" },
+  projects: [{ name: "chromium", use: { browserName: "chromium" } }],
+});
+```
+
+Add to `apps/web/package.json` scripts: `"e2e": "playwright test"`.
+
+- [ ] **Step 2: Write the fixture that can force a decline**
+
+Create `apps/web/e2e/fixtures.ts`:
+
+```ts
+import { request as pwRequest } from "@playwright/test";
+
+const GATEWAY = process.env.GATEWAY_URL ?? "http://localhost:8000";
+
+// Payment declines when the total's minor units satisfy % 100 === 1
+// (services/payment/src/charge.ts:8). The storefront cannot choose an amount — the total comes
+// from catalog prices through Order's read model — so a decline walk has to create a product
+// priced to land there. 99 is deliberately avoided: that is the async webhook path, which
+// parks in PROCESSING and never settles on its own.
+export const DECLINING_PRICE = 1301;
+export const SETTLING_PRICE = 1300;
+
+export async function createProduct(price: number, tag: string): Promise<string> {
+  const ctx = await pwRequest.newContext({ baseURL: GATEWAY });
+  const login = await ctx.post("/auth/login", {
+    data: { email: process.env.ADMIN_EMAIL, password: process.env.ADMIN_PASSWORD },
+  });
+  if (!login.ok()) throw new Error(`admin login failed: ${login.status()}`);
+  const res = await ctx.post("/products", {
+    data: {
+      type: "ELECTRONICS",
+      name: `${tag}-${Date.now()}`,
+      price,
+      attributes: { manufacturer: "e2e", model: tag },
+    },
+  });
+  if (!res.ok()) throw new Error(`product create failed: ${res.status()}`);
+  const body = await res.json();
+  await ctx.dispose();
+  return body.id;
+}
+```
+
+Read `services/catalog`'s create route and its per-type attribute schema before finalising the payload — the shape must match what catalog actually validates. Stock must also exist in Inventory for the product, or the saga cancels at the reservation leg; seed it the way `infra/scripts/drive-checkouts.ts` expects.
+
+- [ ] **Step 3: Write the three walks**
+
+`apps/web/e2e/checkout.spec.ts` — register or sign in, add the `SETTLING_PRICE` product, check out, and assert the tracker reaches `CONFIRMED` **without a reload**:
+
+```ts
+import { test, expect } from "@playwright/test";
+import { createProduct, SETTLING_PRICE } from "./fixtures";
+
+test("browse → cart → checkout → the pipeline confirms live", async ({ page }) => {
+  const productId = await createProduct(SETTLING_PRICE, "e2e-settle");
+  await page.goto(`/products/${productId}`);
+  await page.getByRole("button", { name: /add to cart/i }).click();
+  await page.getByRole("textbox", { name: /email/i }).fill(process.env.E2E_EMAIL!);
+  await page.getByRole("textbox", { name: /password/i }).fill(process.env.E2E_PASSWORD!);
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await page.getByRole("link", { name: /cart/i }).click();
+  await page.getByRole("button", { name: /place order/i }).click();
+  await expect(page.getByRole("listitem", { current: "step" })).toContainText(/inventory|payment/i);
+  // No reload anywhere in this assertion: reaching CONFIRMED proves the stream, not the query.
+  await expect(page.getByText("CONFIRMED")).toBeVisible({ timeout: 30_000 });
+});
+```
+
+`apps/web/e2e/compensation.spec.ts` — identical up to checkout, using `DECLINING_PRICE`, then assert the failed step and `CANCELLED`.
+
+`apps/web/e2e/session-expiry.spec.ts` — place an order, clear the access-token cookie mid-saga (`page.context().clearCookies({ name: … })` for the access cookie only, leaving the refresh cookie), and assert the tracker still reaches its terminal state — this is what exercises the ladder's refresh rung (8b's deferred walk).
+
+- [ ] **Step 4: Run them**
+
+```bash
+docker compose up -d
+pnpm --filter @ecom/web dev &   # or point WEB_URL at the nginx build from Task 10
+pnpm --filter @ecom/web e2e
+```
+
+Expected: 3 passed. A failure here is a real finding — record it, do not weaken the assertion.
+
+- [ ] **Step 5: Document and commit**
+
+Add a short "Storefront e2e" section to `docs/infra.md`: prerequisites, the env vars the fixtures read, and the two commands. Then:
+
+```bash
+pnpm typecheck && pnpm lint && pnpm format:check
+git add apps/web/playwright.config.ts apps/web/e2e apps/web/package.json pnpm-lock.yaml docs/infra.md
+git commit -m "test(web): three local walks, including the compensation path"
+```
+
+---
+
+### Task 10: Packaging
+
+**Files:**
+
+- Create: `apps/web/Dockerfile`, `apps/web/nginx.conf`
+- Modify: `docker-compose.prod.example.yml`
+
+- [ ] **Step 1: Write the nginx config**
+
+Create `apps/web/nginx.conf`:
+
+```nginx
+server {
+  listen 80;
+  server_name _;
+  root /usr/share/nginx/html;
+
+  # A deep link (/orders/abc) is a client route, not a file.
+  location / {
+    try_files $uri /index.html;
+  }
+
+  location /api/ {
+    proxy_pass http://gateway:8000/;
+    proxy_http_version 1.1;
+    # LOAD-BEARING: with buffering on, nginx accumulates the SSE stream and the tracker sits
+    # motionless while the backend works perfectly — a backend success that reads as a
+    # frontend bug.
+    proxy_buffering off;
+    proxy_cache off;
+    # Must outlive an idle stream between the service's 15s heartbeats.
+    proxy_read_timeout 1h;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
+}
+```
+
+- [ ] **Step 2: Write the Dockerfile**
+
+Create `apps/web/Dockerfile`:
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM node:22-alpine AS build
+RUN corepack enable
+WORKDIR /repo
+# Unlike the services (which run TypeScript through tsx and have NO build step), the app is a
+# real Vite build: the browser gets static assets, not source.
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml tsconfig.base.json ./
+COPY packages ./packages
+COPY apps/web ./apps/web
+RUN pnpm install --frozen-lockfile
+RUN pnpm --filter @ecom/web build
+
+FROM nginx:alpine AS runtime
+COPY --from=build /repo/apps/web/dist /usr/share/nginx/html
+COPY apps/web/nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+```
+
+- [ ] **Step 3: Add the service to the prod overlay**
+
+In `docker-compose.prod.example.yml` (an overlay — a service defined only here is still created):
+
+```yaml
+  # The storefront. Published because it is the human entry point; the gateway keeps its own
+  # published port because the payment provider's webhook is an inbound call that does not
+  # pass through nginx.
+  web:
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
+    depends_on: [gateway]
+    ports: ["8080:80"]
+    restart: unless-stopped
+```
+
+- [ ] **Step 4: Verify by running it**
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.example.yml up -d --build web
+```
+
+Then, in a browser at `http://localhost:8080`: hard-refresh a deep link (`/orders/<id>`) and confirm the app renders rather than a 404; place an order and confirm the tracker **advances without a reload through nginx**. The second check is the one that catches a buffering regression, and no test can substitute for it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+pnpm format:check
+git add apps/web/Dockerfile apps/web/nginx.conf docker-compose.prod.example.yml
+git commit -m "feat(web): packaged behind nginx, with the stream unbuffered"
+```
+
+---
+
+### Task 11: Carried debt
+
+**Files:**
+
+- Modify: `packages/contracts/src/http/order.ts`, `apps/web/src/api/cart.ts`, `services/order/src/metrics.ts`
+- Test: extend `apps/web/src/api/__tests__/cart.test.ts`, `apps/web/src/routes/__tests__/Cart.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `apps/web/src/api/__tests__/cart.test.ts`, add a case proving an unknown field is now rejected:
+
+```ts
+it("rejects a cart response carrying an unknown field", async () => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(JSON.stringify({ userId: "u1", items: [], surprise: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })
+  );
+  await expect(getCart()).rejects.toThrow(/did not match its contract/);
+});
+```
+
+In `apps/web/src/routes/__tests__/Cart.test.tsx`, add the two missing cases from 8b: setting a quantity to zero removes the line, and a multi-line cart's estimate is the sum of its lines.
+
+- [ ] **Step 2: Run and watch them fail**
+
+Run: `pnpm vitest run apps/web/src/api/__tests__/cart.test.ts apps/web/src/routes/__tests__/Cart.test.tsx`
+Expected: the strictness case FAILS (extra keys are currently stripped silently).
+
+- [ ] **Step 3: Tighten the contract**
+
+In `packages/contracts/src/http/order.ts`, make `CartItemSchema` and `CartSchema` strict:
+
+```ts
+export const CartItemSchema = z.object({ … }).strict();
+export const CartSchema = z.object({ … }).strict();
+```
+
+This is two-sided: Order asserts its own cart responses against these schemas
+(`services/order/src/__tests__/cart-order-contract.int.test.ts`), so an additive server field now
+fails a backend test beside the change that caused it. Nothing sends extras today, so the change
+is inert on landing and load-bearing afterwards.
+
+- [ ] **Step 4: Fix the stale comment**
+
+In `apps/web/src/api/cart.ts`, the comment claiming a 200 for `POST /cart/items` becomes 201 — the route answers 201 (`services/order/src/app.ts:48`).
+
+- [ ] **Step 5: Widen the saga histogram**
+
+In `services/order/src/metrics.ts`, add boundaries near 1.5 and 2 seconds to `SAGA_BUCKETS`. 7d reproduced by hand that the 1 → 2.5 gap overestimates saga p99 in that range; the `<5s` SLO is unaffected either way.
+
+- [ ] **Step 6: Run the affected suites**
+
+Run: `pnpm vitest run apps/web packages services/order/src/__tests__/cart-order-contract.int.test.ts services/order/src/__tests__/saga-metrics.unit.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Gates and commit**
+
+```bash
+pnpm typecheck && pnpm lint && pnpm format:check
+git add packages/contracts/src/http/order.ts apps/web/src/api/cart.ts apps/web/src/api/__tests__/cart.test.ts apps/web/src/routes/__tests__/Cart.test.tsx services/order/src/metrics.ts
+git commit -m "fix: close the minors 8b and 7d left behind"
+```
+
+---
+
+## Acceptance (run before requesting the whole-branch review)
+
+- [ ] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm -r build` all clean.
+- [ ] `pnpm vitest run` — whole workspace green.
+- [ ] Compose stack up; place an order in a browser and watch the tracker advance **with no reload**.
+- [ ] Force a decline (a product priced `…01`) and see the failed step and `CANCELLED`.
+- [ ] Break the stream mid-saga (stop `order`, or block SSE in devtools) and confirm the page lands on polling and still reaches its terminal state.
+- [ ] `/orders` lists your orders and nobody else's.
+- [ ] Keyboard-only walk of the tracker and the forms; then re-check with `prefers-reduced-motion: reduce` forced in devtools.
+- [ ] `docker compose -f docker-compose.yml -f docker-compose.prod.example.yml up -d --build web`, then a live tracker at `http://localhost:8080`.
+- [ ] Write `.scratch/phase-8c/impl-notes.html` as deviations occur — do not reconstruct it at the end.

--- a/docs/superpowers/specs/2026-08-04-phase-8c-tracker-polish-design.md
+++ b/docs/superpowers/specs/2026-08-04-phase-8c-tracker-polish-design.md
@@ -1,0 +1,339 @@
+# Phase 8c · Order-pipeline tracker + polish — Design (child spec)
+
+Parent: `2026-07-18-microservices-streaming-rebuild-design.md` §Phase 8
+Roadmap: `2026-07-23-phases-3-8-roadmap.md` §Phase 8, slice 8c
+Siblings: `2026-07-30-phase-8a-storefront-foundation-design.md`, `2026-08-03-phase-8b-auth-cart-checkout-design.md`
+
+## Purpose
+
+8b left a storefront that can transact but cannot show what happens next: the order page renders
+a status that only a manual reload changes. 8c makes the saga visible. The order-pipeline
+tracker is the phase's signature element — the one screen where a choreographed distributed
+transaction stops being an architecture diagram and becomes something a user watches resolve.
+
+This is also the last slice of the 3–8 roadmap. Everything it leaves behind is unscheduled
+backlog, not a planned successor, so the deferral bar here is higher than in earlier slices.
+
+## Scope
+
+**In:** the live tracker on `/orders/:id` (SSE with a terminating fallback ladder to polling);
+order history at `/orders`, backed by a new `GET /orders` on the Order service; an accessibility
+sweep including `prefers-reduced-motion`; a local Playwright e2e suite; `apps/web/Dockerfile`
+plus nginx and a prod-compose entry; and four pieces of carried debt (§H).
+
+**Out:** guest carts, addresses and shipping, cancelling or refunding from the UI, an admin or
+ops surface, a Playwright lane in CI (§F4), and cursor pagination on order history (§D2).
+
+## Preconditions
+
+Verified against the tree at `936842b` (8b merged) before this spec was written:
+
+| Fact | Where |
+|---|---|
+| `GET /orders/:id/stream` exists: `event: status`, `data {orderId,status}`, `:keepalive` every 15s, closes on terminal | `services/order/src/app.ts:214` |
+| The stream 404s a non-owner **before** any SSE header is written | `services/order/src/app.ts:224` |
+| The stream answers 503 when the registry is absent, 400 without `x-user-id` | `services/order/src/app.ts:216` |
+| The gateway proxies the stream authenticated and **exempt from breaker + timeout** | `services/gateway/src/app.ts:210`, `proxy.ts:27` |
+| Order has **no list endpoint** — only `POST /orders`, `GET /orders/:id`, `GET /orders/:id/stream` | `services/order/src/app.ts` |
+| `OrderStatusSchema` is exactly `PENDING \| AWAITING_PAYMENT \| CONFIRMED \| CANCELLED` | `packages/contracts/src/http/order.ts:28` |
+| `PENDING`+reserved → `AWAITING_PAYMENT`; `PENDING`+reservation-failed → `CANCELLED`; `AWAITING_PAYMENT`+payment-failed → `CANCELLED` — the whole basis of §A1 | `services/order/src/transition.ts:14` |
+| `request()` owns the single-flight refresh and one retry; `HttpError` carries a status and nothing else | `apps/web/src/api/request.ts`, `errors.ts` |
+| The browser calls same-origin `/api/*`; Vite strips the prefix in dev | `apps/web/vite.config.ts` |
+| jsdom provides **no** `EventSource` | `apps/web/vitest.config.ts` (environment: jsdom) |
+
+## A. Four statuses, four steps
+
+### A1. The tracker derives its steps client-side
+
+The umbrella prototype draws the pipeline as `PENDING → InventoryReserved → PaymentSucceeded →
+CONFIRMED`, but the stream carries an `Order.status`, and "inventory reserved" is not one. It
+does not need to be: **an order cannot reach `AWAITING_PAYMENT` unless the reservation
+succeeded** — the transition is written by the reserve-leg consumer, and a failed reservation
+cancels instead. `AWAITING_PAYMENT` is therefore *evidence* of a reserved inventory and an
+in-flight charge, and the four steps are recoverable from the four statuses without touching a
+service.
+
+| Status | Placed | Inventory reserved | Payment | Confirmed |
+|---|---|---|---|---|
+| `PENDING` | done | active | pending | pending |
+| `AWAITING_PAYMENT` | done | done | active | pending |
+| `CONFIRMED` | done | done | done | done |
+| `CANCELLED` | done | *see below* | failed | — |
+
+`CANCELLED` is the compensation path and is the one row that cannot be read off the status
+alone: an order cancelled by a reservation failure never reserved anything, while one cancelled
+by a declined payment reserved and then released. The status does not say which. **The tracker
+renders the failure against the step that was active when the terminal frame arrived**, and
+falls back to marking *payment* failed when the page is loaded cold on an already-cancelled
+order. That is honest — a cold load genuinely does not know — and it is recorded here so a
+reviewer does not read it as a bug.
+
+The alternative, emitting saga sub-events so the client is told rather than inferring, means a
+new column, a migration, and a new frame DTO. Rejected: it inflates the last slice of the
+roadmap to make an inference that is already sound for three of four rows.
+
+### A2. The mapping lives in one pure module
+
+`apps/web/src/order/saga-steps.ts` exports `stepsFor(status, activeAtTerminal?)` returning a
+list of `{key, label, state}` with `state: "done" | "active" | "failed" | "pending"`. No React,
+no EventSource, no fetch. Every claim in §A1's table is one row of one unit test, and the
+component that renders it never learns what `AWAITING_PAYMENT` implies.
+
+## B. Liveness
+
+### B1. The stream writes into the query cache, and the page reads only the cache
+
+`useOrderStream(id)` opens the EventSource and, for each frame, does
+
+```ts
+queryClient.setQueryData(["order", id], (old) => old && { ...old, status: frame.status });
+```
+
+The route continues to render from `useQuery(["order", id])`. One source of truth, so a page
+that remounts or a badge rendered elsewhere cannot disagree with the tracker, and the polling
+fallback (§B2) needs no separate data path — it is a flag on the same query.
+
+**The `old &&` guard is load-bearing.** The stream sends the current status immediately on
+subscribe, so a frame routinely arrives before `GET /orders/:id` resolves. Without the guard,
+`setQueryData` would materialise `{status}` with no `items` and no `totalPrice`, and the route —
+which trusts a resolved query — would render an order with no lines. This is the same class of
+bug as 8b's "fabricated `$0.00`", and it is the reason the stream is not allowed to *create*
+cache entries, only to advance one.
+
+### B2. The fallback ladder terminates
+
+`EventSource` reconnects on its own, forever, and exposes no status code — a 401 from an expired
+access token, a 404 on someone else's order, and a dropped Wi-Fi connection are the same
+`onerror` event. The ladder therefore counts errors rather than interpreting them:
+
+1. **First `onerror`** — call `refreshSession()` (the existing single-flight helper) once, then
+   let EventSource reconnect. An access token expiring mid-saga is the expected cause, and it is
+   the only one the client can fix.
+2. **Third `onerror`** — `es.close()`, switch the query to `refetchInterval: 3000`.
+3. **Terminal status** (`CONFIRMED` or `CANCELLED`), from either transport — close the stream,
+   clear the interval, stop. A settled order never polls.
+4. **Unmount** — close both.
+
+**Never both transports at once.** Running SSE and polling together would keep the page correct
+while the stream is completely broken, which is precisely the failure this phase exists to make
+visible.
+
+The ladder must terminate for a second reason: a stream for an order the caller does not own
+404s before any SSE header, so an infinite reconnect would retry a permanent failure forever and
+show nothing. Falling to polling makes `GET /orders/:id` answer 404 and hands the user 8b's
+existing "Order not found" view.
+
+3s is chosen against the <5s saga SLO (`k6/checkout.js`): fast enough that a fallback user sees
+the pipeline move, slow enough that a settled-but-open page is not a load source. It is a
+constant in one module, not a scattered literal.
+
+### B3. `EventSource` is injected, because jsdom has none
+
+`apps/web/src/api/stream.ts` exports `openOrderStream(id, handlers, { create })` where `create`
+defaults to `(url) => new EventSource(url)`. Tests pass a fake that records `close()` calls and
+fires `onerror`/`onmessage` on demand. Without the seam, every ladder rule in §B2 would be
+provable only by hand in a browser — and 7c's lesson stands: a test that cannot fail is worse
+than no test.
+
+The URL is `/api/orders/:id/stream`, same-origin, so the session cookie rides automatically;
+`EventSource` cannot set headers, which is why the gateway authenticates the stream from the
+cookie and not from a bearer token (already true since 6b).
+
+## C. Rendering
+
+`OrderTracker` takes a status and renders steps. It is presentational, has no hooks beyond
+layout, and is the only place the design language's colour rules apply.
+
+**Colour is never the only channel.** The design language reserves amber/green/red to encode
+saga state, so each step carries an icon and a text label as well; a red step reads as failed in
+greyscale and to a screen reader.
+
+The tracker is an ordered list. The active step carries `aria-current="step"`, and a visually
+hidden `aria-live="polite"` region announces transitions ("Payment confirmed"). Polite, not
+assertive: a status change is not an interruption, and the saga can produce three in a few
+seconds.
+
+Under `prefers-reduced-motion: reduce` the active step's pulse is **removed, not substituted** —
+no cross-fade, no slower pulse. The step still reads as active through `aria-current`, its icon,
+and its colour.
+
+The sweep beyond the tracker: a skip link in `Layout`, heading order checked per route, visible
+focus rings, and a label on every input in Login, Register and Cart. Bounded and named here so
+it does not become an open-ended redesign.
+
+## D. Order history
+
+### D1. `GET /orders` is a new endpoint, and the gateway needs no change
+
+The Order service gains a list scoped by `x-user-id`, ordered `createdAt desc`, capped at 50
+rows, returning a summary per order: `{id, status, totalPrice, createdAt, itemCount}`. Ownership
+stays where every other order route keeps it — in the service, not the gateway.
+
+The gateway's `RULES` table is an allowlist of *permissions*, not of routes: anything absent
+needs authentication only. `GET /orders` is absent, and `app.use("/orders", authRequired, authz,
+guard("order", …))` already proxies it. **No gateway file changes**, and that is a claim the
+plan should verify by test rather than by reading.
+
+`OrderSummarySchema` is a new contract; `itemCount` is served from a Prisma `_count`, so a
+history row can say "3 items" without shipping every line.
+
+### D2. The cap is a decision, not an omission
+
+50 rows, no cursor, no page control. A learning storefront has no user with 51 orders, and a
+half-built pagination is worse than a documented ceiling. The response is a plain array; if the
+ceiling ever matters, adding a cursor is a widening change, not a breaking one.
+
+### D3. `/orders` the page and `/api/orders` the API cannot collide
+
+8a's `/api/*` decision is what makes this safe: the proxy owns one prefix and the router owns
+the origin root, so a hard refresh on `/orders` serves the app. This is the exact bug 8a hit
+with `/products` and the reason the prefix exists.
+
+## E. Error handling
+
+### E1. `HttpError` learns to carry a body
+
+`request()` reads the error body when the response declares JSON, and attaches it as
+`HttpError.body`. That closes 8b's §D1 drift: Order deliberately puts `productId` in its 422
+body, but `HttpError(status)` discarded it, so checkout's recovery said "one of these products"
+instead of naming it. With the body available, `describeCheckoutFailure` joins the id against
+the cached catalogue and names the product.
+
+Parsing is best-effort and must never throw: a non-JSON or truncated error body leaves
+`body: undefined` and the generic message, exactly as today. The status remains the field
+everything branches on.
+
+### E2. The failure taxonomy is unchanged
+
+`NetworkError`, `HttpError`, `SchemaMismatchError`, `UnauthenticatedError` keep their meanings.
+A stream failure is not added to the taxonomy — the ladder resolves it into either a working
+transport or an ordinary query error, so nothing above `useOrderStream` learns that SSE exists.
+
+## F. Testing
+
+### F1. Unit
+
+- `stepsFor` — one case per row of §A1's table, plus the cold-load `CANCELLED` fallback.
+- The ladder, against the fake EventSource: exactly one `refreshSession()` across a burst of
+  errors; polling starts on the third error and not before; a terminal frame stops everything;
+  unmount closes the stream; polling never runs while the stream is open.
+- `setQueryData` guard: a frame arriving before the GET resolves leaves the cache untouched.
+
+### F2. Component
+
+Tracker at each status, the compensation branch, and the reduced-motion variant; history list,
+empty and error states.
+
+### F3. Backend integration
+
+`GET /orders` returns only the caller's orders, newest first, capped at 50, with `itemCount`
+matching the lines. Runs against live Postgres like 8b's order contract test, and tags and
+deletes its own rows per the 7d convention.
+
+### F4. Playwright, local only
+
+`pnpm --filter @ecom/web e2e` against a running compose stack. Three walks:
+
+1. browse → add to cart → login → checkout → the tracker reaches `CONFIRMED` live;
+2. the compensation path, forced with the declining magic amount (minor-units total
+   `% 100 == 1`) → the tracker shows the failed step and `CANCELLED`;
+3. a session expiring mid-order — 8b's deferred mid-session-expiry walk, which is what proves
+   the ladder's refresh rung.
+
+CI stays out. The `quality` job auto-globs `services/*` and has no compose stack; standing up
+eight services, Kafka, RabbitMQ and Postgres to run three browser walks is its own slice, and
+attempting it inside the last storefront slice would spend most of the slice debugging a runner.
+Stated here so the absence is a decision on the record, not a gap.
+
+## G. Packaging
+
+`apps/web/Dockerfile` is multi-stage: a Node stage runs `pnpm --filter @ecom/web build` (the app
+needs a real Vite build, unlike the services, which run TypeScript through tsx), and the output
+is copied into `nginx:alpine`.
+
+nginx does two things. `try_files $uri /index.html` so a deep link survives a refresh, and
+
+```
+location /api/ {
+  proxy_pass http://gateway:8000/;
+  proxy_http_version 1.1;
+  proxy_buffering off;
+  proxy_read_timeout 1h;
+}
+```
+
+**`proxy_buffering off` is the load-bearing line.** With buffering on, nginx accumulates the
+stream and the tracker sits motionless while the backend works perfectly — a failure that looks
+like a frontend bug and is not. `proxy_read_timeout` must outlive an idle stream between
+heartbeats; the service sends `:keepalive` every 15s, so anything over a minute would do and an
+hour removes the question.
+
+The `web` service is added to `docker-compose.prod.example.yml` only. Dev keeps the Vite dev
+server — HMR is the reason it exists, and containerising dev trades it for nothing. The overlay
+may introduce a service the base file does not define, so no change to
+`docker-compose.example.yml` is needed. The gateway keeps its published port: the payment
+provider's webhook is an inbound call that does not pass through nginx.
+
+## H. Carried debt closed here
+
+| Item | Origin |
+|---|---|
+| `HttpError` carries a parsed body; 422 names the product | 8b §D1 drift (§E1) |
+| Cart contract schemas become strict; `cart.ts` comment says 201, not 200 | 8b deferred minors |
+| `SAGA_BUCKETS` gains boundaries near 1.5s and 2s in `services/order/src/metrics.ts` | 7d lesson: the 1→2.5 gap overestimates saga p99 in that range |
+| Cart tests for decrement-to-zero and a multi-line estimate | 8b deferred minors |
+
+The `SAGA_BUCKETS` change is backend and unrelated to the storefront; it is here because this
+slice already opens `services/order` for §D1, and carrying it further means carrying it forever.
+
+## I. Decisions
+
+| # | Decision | Why |
+|---|---|---|
+| 1 | Steps derived client-side from four statuses | §A1 — `AWAITING_PAYMENT` proves the reservation; sub-events cost a migration |
+| 1a | Cold-loaded `CANCELLED` marks *payment* failed | §A1 — the status cannot distinguish the two cancellation causes |
+| 2 | The mapping is a pure module | §A2 — one place knows the saga; the component knows nothing |
+| 3 | Stream writes the query cache; page reads the cache | §B1 — one source of truth, and fallback is a flag on the same query |
+| 3a | `setQueryData` never creates an entry | §B1 — the first frame beats the GET, and a `{status}`-only order renders lines-less |
+| 4 | Ladder: refresh once, poll after 3 errors, stop on terminal | §B2 — EventSource hides status codes; a 404 stream must not retry forever |
+| 4a | Never SSE and polling together | §B2 — parallel polling hides a totally broken stream |
+| 5 | `EventSource` injected via a factory | §B3 — jsdom has none, and an untestable ladder is an unverified ladder |
+| 6 | Colour is never the only state channel | §C — the design language encodes state in colour; a11y forbids relying on it |
+| 6a | Reduced motion removes the pulse, substitutes nothing | §C |
+| 7 | `GET /orders` added to the Order service | §D1 — history needs it; a client-side order log would be fiction |
+| 7a | No gateway change | §D1 — `RULES` is a permission allowlist; ownership belongs to the service |
+| 7b | 50 rows, no cursor | §D2 — a documented ceiling beats half a pagination |
+| 8 | `HttpError.body`, best-effort, never throws | §E1 — closes 8b's §D1 without changing what code branches on |
+| 9 | Playwright local-only | §F4 — a compose-backed CI lane is its own slice |
+| 10 | nginx in the prod overlay only; `proxy_buffering off` | §G — buffering silently freezes the tracker |
+
+## Done when
+
+- [ ] The tracker animates `PENDING → AWAITING_PAYMENT → CONFIRMED` live in a browser, with no
+      reload, on a real compose stack.
+- [ ] A forced payment failure shows the compensation path and `CANCELLED`.
+- [ ] Killing the stream mid-saga (stop the order service's stream, or block SSE) lands on
+      polling and the page still reaches its terminal state.
+- [ ] `/orders` lists the caller's orders and nobody else's, proven by an integration test.
+- [ ] The tracker is operable and comprehensible with a keyboard and a screen reader, and still
+      static under `prefers-reduced-motion`.
+- [ ] Three Playwright walks green locally against compose.
+- [ ] `docker compose -f docker-compose.yml -f docker-compose.prod.example.yml up` serves the
+      storefront through nginx, including a live tracker through the proxy.
+- [ ] `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm -r build` and the full test suite
+      clean — lint included per 7c's lesson.
+- [ ] Every item in §H closed.
+
+## Risks
+
+**The tracker looks finished but is not live.** Every gate in this repo — typecheck, lint, jsdom
+tests — passed over 8a's permanently-dark palette and its JSON-instead-of-app bug, and over 7c's
+entirely non-functional tracing. A green suite proves nothing about liveness here. The
+acceptance walk on a real stack is the gate that counts, and it must include watching a
+transition arrive without a reload.
+
+**nginx buffering.** §G. It fails only in the packaged shape, which is the shape least often
+run.
+
+**Scope drift through the a11y sweep.** "Accessibility" can absorb an unbounded redesign. §C
+names the surfaces; anything else is a finding for the backlog, not this slice.

--- a/docs/superpowers/specs/2026-08-04-phase-8c-tracker-polish-design.md
+++ b/docs/superpowers/specs/2026-08-04-phase-8c-tracker-polish-design.md
@@ -63,10 +63,11 @@ service.
 `CANCELLED` is the compensation path and is the one row that cannot be read off the status
 alone: an order cancelled by a reservation failure never reserved anything, while one cancelled
 by a declined payment reserved and then released. The status does not say which. **The tracker
-renders the failure against the step that was active when the terminal frame arrived**, and
-falls back to marking *payment* failed when the page is loaded cold on an already-cancelled
-order. That is honest — a cold load genuinely does not know — and it is recorded here so a
-reviewer does not read it as a bug.
+marks a specific step failed only when it observed the transition live** — the step that was
+active when the terminal frame arrived is the one that failed. On a cold load of an
+already-cancelled order it names **no** step: the pipeline renders as ended and the card says
+the order was cancelled. Guessing "payment" there would be a false statement to the user for
+every reservation-failed order, and "we do not know" is a thing this UI is allowed to say.
 
 The alternative, emitting saga sub-events so the client is told rather than inferring, means a
 new column, a migration, and a new frame DTO. Rejected: it inflates the last slice of the
@@ -106,10 +107,15 @@ cache entries, only to advance one.
 access token, a 404 on someone else's order, and a dropped Wi-Fi connection are the same
 `onerror` event. The ladder therefore counts errors rather than interpreting them:
 
-1. **First `onerror`** — call `refreshSession()` (the existing single-flight helper) once, then
-   let EventSource reconnect. An access token expiring mid-saga is the expected cause, and it is
-   the only one the client can fix.
-2. **Third `onerror`** — `es.close()`, switch the query to `refetchInterval: 3000`.
+1. **First `onerror`** — **close the stream**, `await refreshSession()` (the existing
+   single-flight helper), then open a *fresh* EventSource. An access token expiring mid-saga is
+   the expected cause and the only one the client can fix. Closing first is not optional:
+   EventSource reconnects on its own timer (~3s — the service sends no `retry:` field), so
+   leaving it open means the reconnect fires *before* the refresh resolves, 401s again, and
+   spends a rung on a problem that was already being fixed. Errors arriving while a refresh is
+   in flight do not increment the counter.
+2. **Third `onerror`** — `es.close()`, switch the query to `refetchInterval: POLL_INTERVAL_MS`
+   (3000).
 3. **Terminal status** (`CONFIRMED` or `CANCELLED`), from either transport — close the stream,
    clear the interval, stop. A settled order never polls.
 4. **Unmount** — close both.
@@ -123,17 +129,29 @@ The ladder must terminate for a second reason: a stream for an order the caller 
 show nothing. Falling to polling makes `GET /orders/:id` answer 404 and hands the user 8b's
 existing "Order not found" view.
 
-3s is chosen against the <5s saga SLO (`k6/checkout.js`): fast enough that a fallback user sees
-the pipeline move, slow enough that a settled-but-open page is not a load source. It is a
-constant in one module, not a scattered literal.
+`POLL_INTERVAL_MS = 3000` is chosen against the `saga_duration p(99)<5000` threshold
+(`k6/checkout.js:21`): fast enough that a fallback user sees the pipeline move, slow enough that
+a settled-but-open page is not a load source. It is a named constant in one module, never a
+literal at a call site.
 
-### B3. `EventSource` is injected, because jsdom has none
+### B3. The frame is a NAMED event, and `EventSource` is injected
+
+The service writes `event: status\ndata: {...}` (`services/order/src/app.ts:241`). `EventSource`
+delivers a **named** event only to `addEventListener("status", …)` — `onmessage` fires for
+unnamed frames and would therefore **never fire at all** here. The client listens by name, and
+so does the test fake.
+
+This is the single most dangerous detail in the slice: a fake that dispatches through
+`onmessage` makes every ladder test in §F1 pass against a page that receives nothing, which is
+7c's "six tests that pass against a broken implementation" reproduced exactly. The plan's exit
+criterion for the stream module is that removing the `addEventListener("status")` wiring makes a
+test fail.
 
 `apps/web/src/api/stream.ts` exports `openOrderStream(id, handlers, { create })` where `create`
 defaults to `(url) => new EventSource(url)`. Tests pass a fake that records `close()` calls and
-fires `onerror`/`onmessage` on demand. Without the seam, every ladder rule in §B2 would be
-provable only by hand in a browser — and 7c's lesson stands: a test that cannot fail is worse
-than no test.
+dispatches named `status` events plus `error` on demand. The seam is required, not stylistic:
+`EventSource` is `undefined` in the test environment — jsdom does not implement it and Node
+22.21 has no global either.
 
 The URL is `/api/orders/:id/stream`, same-origin, so the session cookie rides automatically;
 `EventSource` cannot set headers, which is why the gateway authenticates the stream from the
@@ -214,9 +232,13 @@ transport or an ordinary query error, so nothing above `useOrderStream` learns t
 ### F1. Unit
 
 - `stepsFor` — one case per row of §A1's table, plus the cold-load `CANCELLED` fallback.
-- The ladder, against the fake EventSource: exactly one `refreshSession()` across a burst of
-  errors; polling starts on the third error and not before; a terminal frame stops everything;
-  unmount closes the stream; polling never runs while the stream is open.
+- Frame delivery: a fake dispatching a **named** `status` event reaches the handler, and the
+  test fails if the listener is registered as `onmessage`.
+- The ladder, against the fake EventSource: rung 1 closes the stream, waits for the refresh, and
+  opens a new one; errors during an in-flight refresh do not count; exactly one
+  `refreshSession()` across a burst of errors; polling starts on the third error and not before;
+  a terminal frame stops everything; unmount closes the stream; polling never runs while the
+  stream is open.
 - `setQueryData` guard: a frame arriving before the GET resolves leaves the cache untouched.
 
 ### F2. Component
@@ -232,13 +254,28 @@ deletes its own rows per the 7d convention.
 
 ### F4. Playwright, local only
 
-`pnpm --filter @ecom/web e2e` against a running compose stack. Three walks:
+`pnpm --filter @ecom/web e2e` against a running compose stack. The slice adds
+`@playwright/test`, a `playwright.config.ts` under `apps/web`, the `e2e` script, and a
+documented `pnpm exec playwright install chromium` step — named here so the plan does not invent
+them. One browser (chromium) only.
+
+Three walks:
 
 1. browse → add to cart → login → checkout → the tracker reaches `CONFIRMED` live;
-2. the compensation path, forced with the declining magic amount (minor-units total
-   `% 100 == 1`) → the tracker shows the failed step and `CANCELLED`;
+2. the compensation path, forced with the declining magic amount — `charge()` returns `FAILED`
+   when minor-units `% 100 == 1` (`services/payment/src/charge.ts:8`) → the tracker shows the
+   failed step and `CANCELLED`;
 3. a session expiring mid-order — 8b's deferred mid-session-expiry walk, which is what proves
    the ladder's refresh rung.
+
+**Walk 2 needs a fixture the storefront cannot produce by clicking.** The total comes from
+catalog prices through Order's read model, so the suite must create its own product priced to
+land on `…01` at quantity 1 (e.g. 1301 minor units) via `POST /products` as an admin, and add
+exactly that one line. There is no catalog seed script to lean on — the only seed in the repo is
+`services/identity/prisma/seed.ts`, and `infra/scripts/drive-checkouts.ts:8` requires a
+`PRODUCT_ID` handed to it. The fixture tags and removes its own product, per 7d's rule that a
+test cleans the dev database it dirtied. Avoid `% 100 == 99`: that is the async-webhook path,
+which parks in `PROCESSING` and never settles on its own.
 
 CI stays out. The `quality` job auto-globs `services/*` and has no compose stack; standing up
 eight services, Kafka, RabbitMQ and Postgres to run three browser walks is its own slice, and
@@ -280,24 +317,33 @@ provider's webhook is an inbound call that does not pass through nginx.
 |---|---|
 | `HttpError` carries a parsed body; 422 names the product | 8b §D1 drift (§E1) |
 | Cart contract schemas become strict; `cart.ts` comment says 201, not 200 | 8b deferred minors |
+| `Order.tsx` stops being headed "Order placed" — it is also reached from history | this slice's own §D |
 | `SAGA_BUCKETS` gains boundaries near 1.5s and 2s in `services/order/src/metrics.ts` | 7d lesson: the 1→2.5 gap overestimates saga p99 in that range |
 | Cart tests for decrement-to-zero and a multi-line estimate | 8b deferred minors |
 
 The `SAGA_BUCKETS` change is backend and unrelated to the storefront; it is here because this
 slice already opens `services/order` for §D1, and carrying it further means carrying it forever.
 
+Strictness on the cart contract is **two-sided**: Order asserts its own cart and order responses
+against these schemas (`services/order/src/__tests__/cart-order-contract.int.test.ts`), so an
+additive server field stops being silent and starts failing a backend test beside the change
+that caused it — which is the point. Nothing currently sends extras, so the change is inert on
+the day it lands and load-bearing afterwards.
+
 ## I. Decisions
 
 | # | Decision | Why |
 |---|---|---|
 | 1 | Steps derived client-side from four statuses | §A1 — `AWAITING_PAYMENT` proves the reservation; sub-events cost a migration |
-| 1a | Cold-loaded `CANCELLED` marks *payment* failed | §A1 — the status cannot distinguish the two cancellation causes |
+| 1a | Cold-loaded `CANCELLED` names no failed step | §A1 — the status cannot distinguish the two causes, and guessing states a falsehood |
 | 2 | The mapping is a pure module | §A2 — one place knows the saga; the component knows nothing |
 | 3 | Stream writes the query cache; page reads the cache | §B1 — one source of truth, and fallback is a flag on the same query |
 | 3a | `setQueryData` never creates an entry | §B1 — the first frame beats the GET, and a `{status}`-only order renders lines-less |
 | 4 | Ladder: refresh once, poll after 3 errors, stop on terminal | §B2 — EventSource hides status codes; a 404 stream must not retry forever |
 | 4a | Never SSE and polling together | §B2 — parallel polling hides a totally broken stream |
-| 5 | `EventSource` injected via a factory | §B3 — jsdom has none, and an untestable ladder is an unverified ladder |
+| 4b | Rung 1 closes, refreshes, reopens | §B2 — otherwise EventSource's own ~3s reconnect races the refresh and burns a rung |
+| 5 | Frames read via `addEventListener("status")`, not `onmessage` | §B3 — the service sends a NAMED event; `onmessage` would never fire |
+| 5a | `EventSource` injected via a factory | §B3 — undefined in jsdom *and* in Node 22, and an untestable ladder is an unverified ladder |
 | 6 | Colour is never the only state channel | §C — the design language encodes state in colour; a11y forbids relying on it |
 | 6a | Reduced motion removes the pulse, substitutes nothing | §C |
 | 7 | `GET /orders` added to the Order service | §D1 — history needs it; a client-side order log would be fiction |

--- a/packages/contracts/src/http/order.ts
+++ b/packages/contracts/src/http/order.ts
@@ -2,18 +2,25 @@ import { z } from "zod";
 
 // The cart and order READ API the storefront consumes. Distinct from the event payloads in
 // ../events/order, which describe what the saga publishes, not what a browser fetches.
-export const CartItemSchema = z.object({
-  productId: z.string(),
-  quantity: z.number().int(),
-});
+// Strict: an additive server field must fail loudly. Order asserts its own cart responses
+// against these same schemas, so drift breaks a backend test beside the change that caused it
+// rather than surfacing months later in a client that quietly ignored the new field.
+export const CartItemSchema = z
+  .object({
+    productId: z.string(),
+    quantity: z.number().int(),
+  })
+  .strict();
 export type CartItem = z.infer<typeof CartItemSchema>;
 
 // No names and no prices — the cart carries ids and quantities only, so any UI must join
 // against the catalogue to render a line.
-export const CartSchema = z.object({
-  userId: z.string(),
-  items: z.array(CartItemSchema),
-});
+export const CartSchema = z
+  .object({
+    userId: z.string(),
+    items: z.array(CartItemSchema),
+  })
+  .strict();
 export type Cart = z.infer<typeof CartSchema>;
 
 // Integer MINOR UNITS, and the price CAPTURED at placement — not today's catalogue price.

--- a/packages/contracts/src/http/order.ts
+++ b/packages/contracts/src/http/order.ts
@@ -44,6 +44,20 @@ export const PlacedOrderSchema = z.object({
 });
 export type PlacedOrder = z.infer<typeof PlacedOrderSchema>;
 
+// The history row. `itemCount` rather than the lines themselves: a list of 50 orders does not
+// need every line, and `GET /orders/:id` already serves them to the page that does.
+export const OrderSummarySchema = z.object({
+  id: z.string(),
+  status: OrderStatusSchema,
+  totalPrice: z.number().int(),
+  itemCount: z.number().int(),
+  createdAt: z.string(),
+});
+export type OrderSummary = z.infer<typeof OrderSummarySchema>;
+
+export const OrderListSchema = z.array(OrderSummarySchema);
+export type OrderList = z.infer<typeof OrderListSchema>;
+
 export const OrderDetailSchema = z.object({
   id: z.string(),
   userId: z.string(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
         specifier: ^3.24.0
         version: 3.25.76
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       '@tailwindcss/vite':
         specifier: 4.3.3
         version: 4.3.3(vite@8.2.0(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -1206,6 +1209,11 @@ packages:
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@prisma/client@6.19.3':
     resolution: {integrity: sha512-mKq3jQFhjvko5LTJFHGilsuQs+W+T3Gm451NzuTDGQxwCzwXHYnIu2zGkRoW+Exq3Rob7yp2MfzSrdIiZVhrBg==}
@@ -2403,6 +2411,11 @@ packages:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2991,6 +3004,16 @@ packages:
 
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   postcss@8.5.19:
     resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
@@ -4176,6 +4199,10 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
   '@prisma/client@6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)':
     optionalDependencies:
       prisma: 6.19.3(typescript@5.9.3)
@@ -5357,6 +5384,9 @@ snapshots:
 
   fresh@0.5.2: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5875,6 +5905,14 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.1.0
       pathe: 2.0.3
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.19:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@testing-library/react':
         specifier: 16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
       '@types/react':
         specifier: ^19.2.0
         version: 19.2.17
@@ -96,6 +99,9 @@ importers:
       jsdom:
         specifier: 30.0.1
         version: 30.0.1(@noble/hashes@1.8.0)
+      pg:
+        specifier: ^8.22.0
+        version: 8.22.0
       tailwindcss:
         specifier: 4.3.3
         version: 4.3.3

--- a/services/order/src/__tests__/order-list.int.test.ts
+++ b/services/order/src/__tests__/order-list.int.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { randomUUID } from "crypto";
+import request from "supertest";
+import { OrderListSchema } from "@ecom/contracts";
+import { createApp } from "../app";
+import { prisma } from "../db";
+
+const app = createApp();
+
+// Tag every order this file seeds so afterAll can find and delete them by a DB query rather
+// than an in-memory id list — a mid-suite throw still gets cleaned up (7d convention).
+const TEST_TAG = "test-order-list-int";
+const tagged = () => `${TEST_TAG}-${randomUUID()}`;
+
+async function seedOrder(userId: string, lines: number, createdAt: Date) {
+  return prisma.order.create({
+    data: {
+      userId,
+      status: "PENDING",
+      totalPrice: 100 * lines,
+      createdAt,
+      items: {
+        create: Array.from({ length: lines }, () => ({
+          productId: `p_${randomUUID()}`,
+          quantity: 1,
+          unitPrice: 100,
+        })),
+      },
+    },
+  });
+}
+
+describe("order list (integration — needs compose up + migrated)", () => {
+  afterAll(async () => {
+    const seeded = await prisma.order.findMany({
+      where: { userId: { startsWith: TEST_TAG } },
+      select: { id: true },
+    });
+    const ids = seeded.map((o) => o.id);
+    if (ids.length > 0) {
+      // Outbox rows are keyed by aggregateId and do not cascade from Order (no FK), so they
+      // are deleted separately or they keep tripping INV4_OUTBOX_UNSENT. OrderItem cascades.
+      await prisma.outbox.deleteMany({ where: { aggregateId: { in: ids } } });
+      await prisma.order.deleteMany({ where: { id: { in: ids } } });
+    }
+    await prisma.$disconnect();
+  });
+
+  it("returns only the caller's orders, newest first, with a line count", async () => {
+    const mine = tagged();
+    const theirs = tagged();
+    const older = await seedOrder(mine, 1, new Date("2026-08-01T00:00:00.000Z"));
+    const newer = await seedOrder(mine, 3, new Date("2026-08-02T00:00:00.000Z"));
+    await seedOrder(theirs, 2, new Date("2026-08-03T00:00:00.000Z"));
+
+    const res = await request(app).get("/orders").set("x-user-id", mine);
+
+    expect(res.status).toBe(200);
+    const parsed = OrderListSchema.parse(res.body);
+    expect(parsed.map((o) => o.id)).toEqual([newer.id, older.id]);
+    expect(parsed[0].itemCount).toBe(3);
+    expect(parsed[1].itemCount).toBe(1);
+  });
+
+  it("caps the list at 50", async () => {
+    const many = tagged();
+    for (let i = 0; i < 51; i++) {
+      await seedOrder(many, 1, new Date(2026, 0, 1, 0, 0, i));
+    }
+    const res = await request(app).get("/orders").set("x-user-id", many);
+    expect(res.body).toHaveLength(50);
+  });
+
+  it("rejects a request with no caller", async () => {
+    const res = await request(app).get("/orders");
+    expect(res.status).toBe(400);
+  });
+});

--- a/services/order/src/app.ts
+++ b/services/order/src/app.ts
@@ -20,6 +20,9 @@ const AddItemSchema = z.object({
 });
 const SetQtySchema = z.object({ quantity: z.number().int().min(0) });
 
+// A ceiling, not a page size: `GET /orders` returns a plain array and has no cursor.
+const ORDER_LIST_LIMIT = 50;
+
 // The caller's identity is the x-user-id header, which ONLY the gateway may set: it strips
 // any client-supplied copy before injecting the value it verified from the JWT (Phase 6).
 // Direct access to this port is closed in the prod compose profile.
@@ -176,6 +179,33 @@ export function createApp(
       });
     } catch {
       log.error("order_place_failed", { traceId: req.traceId });
+      res.status(500).json({ error: "internal error" });
+    }
+  });
+
+  // Caller-scoped history. Capped rather than paginated: a documented ceiling beats half a
+  // pagination, and adding a cursor later widens the response instead of breaking it.
+  app.get("/orders", async (req, res) => {
+    const userId = userIdOf(req);
+    if (!userId) return res.status(400).json({ error: "missing x-user-id" });
+    try {
+      const orders = await prisma.order.findMany({
+        where: { userId },
+        orderBy: { createdAt: "desc" },
+        take: ORDER_LIST_LIMIT,
+        include: { _count: { select: { items: true } } },
+      });
+      res.json(
+        orders.map((o) => ({
+          id: o.id,
+          status: o.status,
+          totalPrice: o.totalPrice,
+          itemCount: o._count.items,
+          createdAt: o.createdAt.toISOString(),
+        }))
+      );
+    } catch {
+      log.error("order_list_failed", { traceId: req.traceId });
       res.status(500).json({ error: "internal error" });
     }
   });

--- a/services/order/src/metrics.ts
+++ b/services/order/src/metrics.ts
@@ -1,7 +1,10 @@
 import { Histogram, type Registry } from "prom-client";
 
 // Straddles the roadmap's saga p99 < 5s SLO.
-const SAGA_BUCKETS = [0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30];
+// 7d reproduced by hand, to four decimals from raw bucket counts, that the 1 → 2.5 gap
+// overestimates saga p99 in exactly the range the saga lands in. 1.5 and 2 close it; the <5s
+// SLO is unaffected either way.
+const SAGA_BUCKETS = [0.1, 0.25, 0.5, 1, 1.5, 2, 2.5, 5, 10, 30];
 
 export function createSagaMetrics(registry: Registry) {
   const stepDuration = new Histogram({


### PR DESCRIPTION
Last slice of the 3–8 roadmap. The saga becomes visible: a live tracker fed by SSE with a fallback ladder that terminates, order history behind a new `GET /orders`, an accessibility pass, three local Playwright walks, and an nginx image for the prod profile.

## What it does

**The tracker derives its four steps from four statuses.** An order cannot reach `AWAITING_PAYMENT` unless the reservation succeeded (`services/order/src/transition.ts:14`), so the status is already the evidence — no saga sub-events, no column, no migration. The one genuinely ambiguous case, a cold-loaded `CANCELLED`, blames no step rather than guessing "payment" and stating a falsehood for every reservation-failed order.

**Liveness is a stream that writes into the query cache**, so the page keeps one source of truth and the polling fallback is a flag on the same query. `EventSource` reconnects forever and hides status codes, so the ladder counts errors instead of interpreting them: rung 1 closes, refreshes, and reopens — closing first, because otherwise its own ~3s reconnect races the refresh — and rung 3 gives up on the transport. A terminal status ends both, and the two transports never run together.

**`GET /orders`** is caller-scoped and capped at 50 with no cursor, a ceiling that is documented and tested. The gateway needed no change: its `RULES` table is a permission allowlist, not a route list.

## Verification

- Full workspace suite green except six pre-existing environmental failures (see below).
- **8 Playwright checks green through the nginx image and through the dev server.** The checkout walk counts transports and asserts exactly one stream request and one order GET — reaching `CONFIRMED` is not proof of liveness, since the polling fallback gets there too.
- Three mutation checks recorded in `.scratch/phase-8c/impl-notes.html`: swapping `addEventListener("status")` for `onmessage`, removing the cache guard, and refreshing without closing each turn a test red.
- Reduced motion and keyboard focus are asserted against the **built** stylesheet, where 8a's Tailwind traps lived.

## Deviations

Full list in `.scratch/phase-8c/impl-notes.html`. The two worth reading: the plan's "prove the gateway needs no change by grepping" was too weak and the spec had already said to prove it by test; and the e2e was racing Order's catalog projection rather than flaking, which the fixture now waits on.

## Known, not caused here

Six suite failures trace to two environmental facts: `notifications.dlq` holds 83 messages parked while mailpit was down, and two orders have been stuck since 2026-07-30. Draining a DLQ destroys dev data, so that call is left to the owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM7LtyERowuLrxRyXfBsTv